### PR TITLE
Add due date field to tasks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
   <h1>Task Tracker</h1>
   <div id="task-form">
     <input type="text" id="task-input" placeholder="New task">
+    <input type="date" id="due-date-input">
     <button id="add-button">Add</button>
   </div>
   <ul id="task-list"></ul>

--- a/public/script.js
+++ b/public/script.js
@@ -9,7 +9,7 @@ function renderTasks(tasks) {
   tasks.forEach(task => {
     const li = document.createElement('li');
     li.dataset.id = task.id;
-    li.textContent = task.text;
+    li.textContent = `${task.text} (Due: ${task.dueDate || 'N/A'})`;
     if (task.done) {
       li.classList.add('done');
     }
@@ -44,14 +44,17 @@ async function loadTasks() {
 
 document.getElementById('add-button').onclick = async () => {
   const input = document.getElementById('task-input');
+  const dueInput = document.getElementById('due-date-input');
   const text = input.value.trim();
+  const dueDate = dueInput.value;
   if (text) {
     await fetch('/api/tasks', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({ text })
+      body: JSON.stringify({ text, dueDate })
     });
     input.value = '';
+    dueInput.value = '';
     loadTasks();
   }
 };

--- a/server.js
+++ b/server.js
@@ -15,10 +15,11 @@ app.get('/api/tasks', (req, res) => {
 
 app.post('/api/tasks', (req, res) => {
   const text = req.body.text;
+  const dueDate = req.body.dueDate;
   if (!text) {
     return res.status(400).json({ error: 'Task text is required' });
   }
-  const task = { id: idCounter++, text, done: false };
+  const task = { id: idCounter++, text, dueDate, done: false };
   tasks.push(task);
   res.status(201).json(task);
 });


### PR DESCRIPTION
## Summary
- add due date input to the task form
- display due dates in the task list
- send due date to the backend when creating tasks
- store due date on the server side

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863340098d88326999cbfc66592726d