### PR TITLE
Add priority support to tasks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,11 @@
   <div id="task-form">
     <input type="text" id="task-input" placeholder="New task">
     <input type="date" id="due-date-input">
+    <select id="priority-select">
+      <option value="high">High</option>
+      <option value="medium" selected>Medium</option>
+      <option value="low">Low</option>
+    </select>
     <button id="add-button">Add</button>
   </div>
   <ul id="task-list"></ul>

--- a/public/script.js
+++ b/public/script.js
@@ -9,7 +9,8 @@ function renderTasks(tasks) {
   tasks.forEach(task => {
     const li = document.createElement('li');
     li.dataset.id = task.id;
-    li.textContent = `${task.text} (Due: ${task.dueDate || 'N/A'})`;
+    li.textContent = `${task.text} (Due: ${task.dueDate || 'N/A'}) [${task.priority}]`;
+    li.classList.add(task.priority);
     if (task.done) {
       li.classList.add('done');
     }
@@ -45,16 +46,19 @@ async function loadTasks() {
 document.getElementById('add-button').onclick = async () => {
   const input = document.getElementById('task-input');
   const dueInput = document.getElementById('due-date-input');
+  const prioritySelect = document.getElementById('priority-select');
   const text = input.value.trim();
   const dueDate = dueInput.value;
+  const priority = prioritySelect.value;
   if (text) {
     await fetch('/api/tasks', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({ text, dueDate })
+      body: JSON.stringify({ text, dueDate, priority })
     });
     input.value = '';
     dueInput.value = '';
+    prioritySelect.value = 'medium';
     loadTasks();
   }
 };

--- a/public/style.css
+++ b/public/style.css
@@ -16,3 +16,7 @@ body {
   text-decoration: line-through;
   color: gray;
 }
+
+.high { color: red; }
+.medium { color: orange; }
+.low { color: green; }

--- a/server.js
+++ b/server.js
@@ -16,10 +16,12 @@ app.get('/api/tasks', (req, res) => {
 app.post('/api/tasks', (req, res) => {
   const text = req.body.text;
   const dueDate = req.body.dueDate;
+  let priority = req.body.priority || 'medium';
+  priority = ['high', 'medium', 'low'].includes(priority) ? priority : 'medium';
   if (!text) {
     return res.status(400).json({ error: 'Task text is required' });
   }
-  const task = { id: idCounter++, text, dueDate, done: false };
+  const task = { id: idCounter++, text, dueDate, priority, done: false };
   tasks.push(task);
   res.status(201).json(task);
 });


### PR DESCRIPTION
## Summary
- allow specifying high/medium/low priority when adding a task
- display priority in the task list and color code by priority
- store priority on the server when creating a task

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686335c6a35c8326bb70aed3cae7303e