### PR TITLE
Allow editing task fields via PUT

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -26,6 +26,21 @@ function renderTasks(tasks) {
       loadTasks();
     };
 
+    const editBtn = document.createElement('button');
+    editBtn.textContent = 'Edit';
+    editBtn.onclick = async () => {
+      const newText = prompt('Task text:', task.text);
+      if (newText === null) return;
+      const newDue = prompt('Due date (YYYY-MM-DD):', task.dueDate || '');
+      const newPriority = prompt('Priority (high, medium, low):', task.priority);
+      await fetch(`/api/tasks/${task.id}`, {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ text: newText, dueDate: newDue, priority: newPriority })
+      });
+      loadTasks();
+    };
+
     const deleteBtn = document.createElement('button');
     deleteBtn.textContent = 'Delete';
     deleteBtn.onclick = async () => {
@@ -33,7 +48,7 @@ function renderTasks(tasks) {
       loadTasks();
     };
 
-    li.append(' ', toggleBtn, ' ', deleteBtn);
+    li.append(' ', toggleBtn, ' ', editBtn, ' ', deleteBtn);
     list.appendChild(li);
   });
 }

--- a/server.js
+++ b/server.js
@@ -52,7 +52,25 @@ app.put('/api/tasks/:id', (req, res) => {
   if (!task) {
     return res.status(404).json({ error: 'Task not found' });
   }
-  task.done = req.body.done === true;
+  const { text, dueDate, priority, done } = req.body;
+  if (text !== undefined) {
+    if (!text.trim()) {
+      return res.status(400).json({ error: 'Task text cannot be empty' });
+    }
+    task.text = text;
+  }
+  if (dueDate !== undefined) {
+    task.dueDate = dueDate;
+  }
+  if (priority !== undefined) {
+    if (!['high', 'medium', 'low'].includes(priority)) {
+      return res.status(400).json({ error: 'Invalid priority value' });
+    }
+    task.priority = priority;
+  }
+  if (done !== undefined) {
+    task.done = done === true;
+  }
   saveTasks();
   res.json(task);
 });


### PR DESCRIPTION
## Summary
- update API to allow editing task text, due date and priority
- add an Edit button in the UI to send updates

## Testing
- `node --check server.js`
- `node --check public/script.js`
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686338dbca148326b8379b5287ce4d65