### PR TITLE
Add filtering and sorting options

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,24 @@
     </select>
     <button id="add-button">Add</button>
   </div>
+  <div id="controls">
+    <select id="status-filter">
+      <option value="all">All</option>
+      <option value="active">Active</option>
+      <option value="completed">Completed</option>
+    </select>
+    <select id="priority-filter">
+      <option value="all">All Priorities</option>
+      <option value="high">High</option>
+      <option value="medium">Medium</option>
+      <option value="low">Low</option>
+    </select>
+    <select id="sort-select">
+      <option value="">No Sorting</option>
+      <option value="dueDate">Sort by Due Date</option>
+      <option value="priority">Sort by Priority</option>
+    </select>
+  </div>
   <ul id="task-list"></ul>
 
   <script src="script.js"></script>

--- a/public/script.js
+++ b/public/script.js
@@ -1,5 +1,18 @@
-async function fetchTasks() {
-  const res = await fetch('/api/tasks');
+async function fetchTasks(filters = {}) {
+  const params = new URLSearchParams();
+  if (filters.priority && filters.priority !== 'all') {
+    params.append('priority', filters.priority);
+  }
+  if (filters.status === 'completed') {
+    params.append('done', 'true');
+  } else if (filters.status === 'active') {
+    params.append('done', 'false');
+  }
+  if (filters.sort) {
+    params.append('sort', filters.sort);
+  }
+  const query = params.toString();
+  const res = await fetch('/api/tasks' + (query ? `?${query}` : ''));
   return await res.json();
 }
 
@@ -54,7 +67,10 @@ function renderTasks(tasks) {
 }
 
 async function loadTasks() {
-  const tasks = await fetchTasks();
+  const status = document.getElementById('status-filter').value;
+  const priorityFilter = document.getElementById('priority-filter').value;
+  const sort = document.getElementById('sort-select').value;
+  const tasks = await fetchTasks({ status, priority: priorityFilter, sort });
   renderTasks(tasks);
 }
 
@@ -77,5 +93,9 @@ document.getElementById('add-button').onclick = async () => {
     loadTasks();
   }
 };
+
+document.getElementById('status-filter').onchange = loadTasks;
+document.getElementById('priority-filter').onchange = loadTasks;
+document.getElementById('sort-select').onchange = loadTasks;
 
 loadTasks();

--- a/public/style.css
+++ b/public/style.css
@@ -7,6 +7,10 @@ body {
   margin-bottom: 10px;
 }
 
+#controls {
+  margin-bottom: 10px;
+}
+
 #task-list li {
   list-style: none;
   margin: 5px 0;

--- a/server.js
+++ b/server.js
@@ -30,7 +30,29 @@ function saveTasks() {
 loadTasks();
 
 app.get('/api/tasks', (req, res) => {
-  res.json(tasks);
+  let results = [...tasks];
+  const { priority, done, sort } = req.query;
+
+  if (priority && ['high', 'medium', 'low'].includes(priority)) {
+    results = results.filter(t => t.priority === priority);
+  }
+
+  if (done === 'true' || done === 'false') {
+    results = results.filter(t => t.done === (done === 'true'));
+  }
+
+  if (sort === 'dueDate') {
+    results.sort((a, b) => {
+      const aDate = a.dueDate ? new Date(a.dueDate) : new Date(8640000000000000);
+      const bDate = b.dueDate ? new Date(b.dueDate) : new Date(8640000000000000);
+      return aDate - bDate;
+    });
+  } else if (sort === 'priority') {
+    const order = { high: 1, medium: 2, low: 3 };
+    results.sort((a, b) => order[a.priority] - order[b.priority]);
+  }
+
+  res.json(results);
 });
 
 app.post('/api/tasks', (req, res) => {


### PR DESCRIPTION
## Summary
- add dropdowns to filter by completion status and priority
- add dropdown to sort by due date or priority
- support filtering and sorting in frontend JS
- implement query parameter handling on the server
- minor style for new control bar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68633ae720788326bb6c108d4ffc7cca