### PR TITLE
Add lockfile and setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Web Task Tracker
+
+This is a simple Express-based task tracker.
+
+## Installation
+
+Before starting the server, install dependencies:
+
+```bash
+npm install
+```
+
+## Usage
+
+Start the application with:
+
+```bash
+npm start
+```
+
+The server will run on port 3000 by default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,55 @@
+{
+  "name": "web-task-tracker",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "web-task-tracker",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2"
+      }
+    }
+  },
+  "dependencies": {
+    "express": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-+ZB1UawjdrPVWB9OimX6v3Qc72COYrIguw82+XWr14ExgN1NlOHkry1CcP22wnFSuqqmBs0uC61XY00udtkp7w==",
+      "requires": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.1",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.11.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- provide a minimal `package-lock.json`
- document installation steps in `README`

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68635df8a4bc8326bce0ab739a658565