### PR TITLE
Use env var for session secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ This will install `sqlite3` which is used for persistence. The database file
 
 ## Usage
 
-Start the application with:
+Set the `SESSION_SECRET` environment variable to a random string and start the application with:
 
 ```bash
+export SESSION_SECRET=your_secret_here
 npm start
 ```
 
-The server will run on port 3000 by default.
+The server will run on port 3000 by default if no `PORT` variable is set.
 
 ## Authentication
 

--- a/server.js
+++ b/server.js
@@ -6,9 +6,13 @@ const bcrypt = require('bcryptjs');
 const app = express();
 
 app.use(express.json());
+const sessionSecret = process.env.SESSION_SECRET || 'tasksecret';
+if (!process.env.SESSION_SECRET) {
+  console.warn('Warning: SESSION_SECRET environment variable not set. Using default insecure secret.');
+}
 app.use(
   session({
-    secret: 'tasksecret',
+    secret: sessionSecret,
     resave: false,
     saveUninitialized: false
   })


### PR DESCRIPTION
## Summary
- read `SESSION_SECRET` environment variable in server.js
- warn when `SESSION_SECRET` isn't set and fall back to a default
- document the new environment variable in the README

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68636f11dae4832686ce92decc05d703