### PR TITLE
Add SQLite-backed session store

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ npm install
 
 This will install `sqlite3` which is used for persistence. The database file
 `tasks.db` will be created automatically on first run.
+Session data is also stored in this database so it survives server restarts.
 
 ## Usage
 

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 const db = require('./db');
 const session = require('express-session');
+const SQLiteStore = require('./sqliteStore');
 const bcrypt = require('bcryptjs');
 const app = express();
 
@@ -14,7 +15,8 @@ app.use(
   session({
     secret: sessionSecret,
     resave: false,
-    saveUninitialized: false
+    saveUninitialized: false,
+    store: new SQLiteStore()
   })
 );
 app.use(express.static(path.join(__dirname, 'public')));

--- a/sqliteStore.js
+++ b/sqliteStore.js
@@ -1,0 +1,63 @@
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+const session = require('express-session');
+
+class SQLiteStore extends session.Store {
+  constructor(options = {}) {
+    super();
+    const dbFile = options.dbFile || path.join(__dirname, 'tasks.db');
+    this.db = new sqlite3.Database(dbFile);
+    this.db.serialize(() => {
+      this.db.run(`CREATE TABLE IF NOT EXISTS sessions (
+        sid TEXT PRIMARY KEY,
+        expires INTEGER,
+        data TEXT
+      )`);
+    });
+  }
+
+  get(sid, cb) {
+    this.db.get('SELECT data, expires FROM sessions WHERE sid = ?', [sid], (err, row) => {
+      if (err) return cb(err);
+      if (!row) return cb();
+      if (row.expires && row.expires < Date.now()) {
+        return this.destroy(sid, cb);
+      }
+      try {
+        const sess = JSON.parse(row.data);
+        return cb(null, sess);
+      } catch (e) {
+        return cb(e);
+      }
+    });
+  }
+
+  set(sid, sessionData, cb) {
+    const expires = sessionData.cookie && sessionData.cookie.expires
+      ? new Date(sessionData.cookie.expires).getTime()
+      : Date.now() + 86400000;
+    const data = JSON.stringify(sessionData);
+    this.db.run(
+      'INSERT OR REPLACE INTO sessions (sid, expires, data) VALUES (?, ?, ?)',
+      [sid, expires, data],
+      cb
+    );
+  }
+
+  destroy(sid, cb) {
+    this.db.run('DELETE FROM sessions WHERE sid = ?', [sid], cb);
+  }
+
+  touch(sid, sessionData, cb) {
+    const expires = sessionData.cookie && sessionData.cookie.expires
+      ? new Date(sessionData.cookie.expires).getTime()
+      : Date.now() + 86400000;
+    this.db.run(
+      'UPDATE sessions SET expires = ? WHERE sid = ?',
+      [expires, sid],
+      cb
+    );
+  }
+}
+
+module.exports = SQLiteStore;


### PR DESCRIPTION
## Summary
- use a custom SQLite-backed session store so sessions persist across restarts
- document that session data is kept in SQLite

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686388f966208326a86b3a013f30ef55