### PR TITLE
Enforce SESSION_SECRET requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Session data is also stored in this database so it survives server restarts.
 
 ## Usage
 
-Set the `SESSION_SECRET` environment variable to a random string and start the application with:
+You **must** set the `SESSION_SECRET` environment variable to a random string or the server will refuse to start. Start the application with:
 
 ```bash
 export SESSION_SECRET=your_secret_here

--- a/server.js
+++ b/server.js
@@ -7,9 +7,10 @@ const bcrypt = require('bcryptjs');
 const app = express();
 
 app.use(express.json());
-const sessionSecret = process.env.SESSION_SECRET || 'tasksecret';
-if (!process.env.SESSION_SECRET) {
-  console.warn('Warning: SESSION_SECRET environment variable not set. Using default insecure secret.');
+const sessionSecret = process.env.SESSION_SECRET;
+if (!sessionSecret) {
+  console.error('SESSION_SECRET environment variable is required');
+  process.exit(1);
 }
 app.use(
   session({


### PR DESCRIPTION
## Summary
- fail fast if `SESSION_SECRET` isn't provided
- clarify README that this variable is mandatory

## Testing
- `node -c server.js`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6863c01661a0832698eead6c6cf37931