### PR TITLE
Add Jest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ Create an account by sending a POST request to `/api/register` with a `username`
 and `password`. Log in via `/api/login` and log out with `/api/logout`. The
 frontend includes a simple form for these actions. Tasks are only accessible
 when logged in.
+
+## Testing
+
+Automated tests are provided using Jest. Run them with:
+
+```bash
+npm test
+```

--- a/db.js
+++ b/db.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const sqlite3 = require('sqlite3').verbose();
 
-const DB_FILE = path.join(__dirname, 'tasks.db');
+const DB_FILE = process.env.DB_FILE || path.join(__dirname, 'tasks.db');
 const db = new sqlite3.Database(DB_FILE);
 
 // Initialize tables

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Basic web based task tracker",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -12,5 +13,9 @@
     "express-session": "^1.17.3",
     "bcryptjs": "^2.4.3",
     "csurf": "^1.11.0"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -18,7 +18,9 @@ app.use(
     secret: sessionSecret,
     resave: false,
     saveUninitialized: false,
-    store: new SQLiteStore()
+    store: new SQLiteStore({
+      dbFile: process.env.DB_FILE || path.join(__dirname, 'tasks.db')
+    })
   })
 );
 app.use(csurf());
@@ -172,7 +174,9 @@ app.use((err, req, res, next) => {
   next(err);
 });
 
-(async () => {
+if (require.main === module) {
   const PORT = process.env.PORT || 3000;
   app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
-})();
+}
+
+module.exports = app;

--- a/sqliteStore.js
+++ b/sqliteStore.js
@@ -5,7 +5,8 @@ const session = require('express-session');
 class SQLiteStore extends session.Store {
   constructor(options = {}) {
     super();
-    const dbFile = options.dbFile || path.join(__dirname, 'tasks.db');
+    const dbFile =
+      options.dbFile || process.env.DB_FILE || path.join(__dirname, 'tasks.db');
     this.db = new sqlite3.Database(dbFile);
     this.db.serialize(() => {
       this.db.run(`CREATE TABLE IF NOT EXISTS sessions (


### PR DESCRIPTION
## Summary
- export Express `app` from `server.js` for testing
- allow overriding DB path via `DB_FILE` environment variable
- add Jest and Supertest as dev dependencies
- create basic API test
- document running tests in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647b3bdffc8326ad22463c6940af8b