### PR TITLE
Add validation for due dates and passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ and `password`. Log in via `/api/login` and log out with `/api/logout`. The
 frontend includes a simple form for these actions. Tasks are only accessible
 when logged in.
 
+Passwords must be at least 8 characters long and include upper and lower case
+letters and a number.
+
 ## Testing
 
 Automated tests are provided using Jest. Run them with:


### PR DESCRIPTION
## Summary
- enforce strong password rules during registration
- validate due dates can't be past or malformed
- document password requirements
- expand tests to cover new validations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864899b2c18832687f1150e58263ec2