### PR TITLE
Improve password hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ npm start
 ```
 
 The server will run on port 3000 by default if no `PORT` variable is set.
+You can configure the bcrypt work factor with the `BCRYPT_ROUNDS` environment
+variable (default `12`). Higher values provide stronger hashing but increase CPU
+usage.
 
 ## Authentication
 

--- a/server.js
+++ b/server.js
@@ -7,6 +7,10 @@ const bcrypt = require('bcryptjs');
 const csurf = require('csurf');
 const app = express();
 
+// Use a higher bcrypt work factor for stronger password hashing.
+// Configurable via the BCRYPT_ROUNDS environment variable.
+const BCRYPT_ROUNDS = parseInt(process.env.BCRYPT_ROUNDS, 10) || 12;
+
 app.use(express.json());
 
 function isValidFutureDate(str) {
@@ -68,7 +72,7 @@ app.post('/api/register', async (req, res) => {
     });
   }
   try {
-    const hashed = await bcrypt.hash(password, 10);
+    const hashed = await bcrypt.hash(password, BCRYPT_ROUNDS);
     const user = await db.createUser({ username, password: hashed });
     req.session.userId = user.id;
     res.json({ id: user.id, username: user.username });


### PR DESCRIPTION
## Summary
- bump bcrypt work factor and make it configurable via `BCRYPT_ROUNDS`
- document new environment variable in the README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686499c9bd148326b97a4c72f5ca58bb