### PR TITLE
Add secure session cookie options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ npm install
 This will install `sqlite3` which is used for persistence. The database file
 `tasks.db` will be created automatically on first run.
 Session data is also stored in this database so it survives server restarts.
+Session cookies are configured with `httpOnly`, `sameSite=lax` and
+`secure` (enabled when `NODE_ENV` is set to `production`) to help protect
+your session from client-side access and CSRF attacks.
 
 ## Usage
 

--- a/server.js
+++ b/server.js
@@ -44,7 +44,12 @@ app.use(
     saveUninitialized: false,
     store: new SQLiteStore({
       dbFile: process.env.DB_FILE || path.join(__dirname, 'tasks.db')
-    })
+    }),
+    cookie: {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax'
+    }
   })
 );
 app.use(csurf());


### PR DESCRIPTION
## Summary
- set `httpOnly`, `secure`, and `sameSite` options for session cookies
- document session cookie security in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b48cdcd483268999bd1737a1e986