### PR TITLE
Improve login/register form UX

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,15 +9,15 @@
 <body>
   <h1>Task Tracker</h1>
     <div id="auth">
-      <div id="login-form">
+      <form id="login-form">
         <label for="username-input">Username</label>
-        <input type="text" id="username-input" placeholder="Username">
+        <input type="text" id="username-input" placeholder="Username" autocomplete="username" required>
         <label for="password-input">Password</label>
-        <input type="password" id="password-input" placeholder="Password">
-        <button id="login-button">Login</button>
-        <button id="register-button">Register</button>
+        <input type="password" id="password-input" placeholder="Password" autocomplete="current-password" required>
+        <button id="login-button" type="submit">Login</button>
+        <button id="register-button" type="button">Register</button>
         <div id="login-error" class="error" aria-live="polite"></div>
-      </div>
+      </form>
       <div id="user-info" style="display:none;">
       Logged in as <span id="current-user"></span>
       <button id="logout-button">Logout</button>

--- a/public/script.js
+++ b/public/script.js
@@ -144,7 +144,8 @@ document.getElementById('status-filter').onchange = loadTasks;
 document.getElementById('priority-filter').onchange = loadTasks;
 document.getElementById('sort-select').onchange = loadTasks;
 
-document.getElementById('login-button').onclick = async () => {
+async function handleLogin(event) {
+  if (event) event.preventDefault();
   const username = document.getElementById('username-input').value.trim();
   const password = document.getElementById('password-input').value;
   const errorEl = document.getElementById('login-error');
@@ -167,7 +168,10 @@ document.getElementById('login-button').onclick = async () => {
       errorEl.textContent = data.error || 'Login failed';
     }
   }
-};
+}
+
+document.getElementById('login-button').onclick = handleLogin;
+document.getElementById('login-form').addEventListener('submit', handleLogin);
 
 document.getElementById('register-button').onclick = async () => {
   const username = document.getElementById('username-input').value.trim();

--- a/public/style.css
+++ b/public/style.css
@@ -32,6 +32,10 @@ body {
 .error {
   color: red;
   margin-top: 5px;
+  font-weight: bold;
+  padding: 4px;
+  border: 1px solid red;
+  background: #fdd;
 }
 
 label {


### PR DESCRIPTION
## Summary
- wrap login controls in a `<form>` so Enter submits the login action
- improve error message styling
- handle login form submission in script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864fbc12c248326a85ef1ee989cd79e