### PR TITLE
Improve CSRF token docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ when logged in.
 Passwords must be at least 8 characters long and include upper and lower case
 letters and a number.
 
+## CSRF Tokens
+
+The application uses CSRF protection on all non-GET requests. Obtain a token
+from `/api/csrf-token` and send it in the `CSRF-Token` header whenever you make
+POST, PUT or DELETE requests.
+
+Changing the session (for example by registering, logging in or logging out)
+invalidates the previous token. Always fetch a fresh token from the same
+endpoint before sending another state-changing request.
+
 ## Testing
 
 Automated tests are provided using Jest. Run them with:


### PR DESCRIPTION
## Summary
- document the CSRF token lifecycle and how to refresh tokens after changing the session

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864fd93cdac8326991c776aa37a7ab7