### PR TITLE
Fix CSRF token error when loading frontend

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,8 +52,8 @@ app.use(
     }
   })
 );
-app.use(csurf());
 app.use(express.static(path.join(__dirname, 'public')));
+app.use(csurf());
 
 app.get('/api/csrf-token', (req, res) => {
   res.json({ csrfToken: req.csrfToken() });


### PR DESCRIPTION
## Summary
- serve static files before enabling CSRF protection

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff82fc508326b5b80fdbe29575ff