### PR TITLE
Add categories to tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a simple Express-based task tracker.
 Tasks are persisted in a local SQLite database (`tasks.db`).
-Each user has their own task list after logging in.
+Each user has their own task list after logging in. Tasks can optionally be assigned a category label so they can be filtered and grouped.
 
 ## Installation
 

--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,8 @@
     <input type="text" id="task-input" placeholder="New task">
     <label for="due-date-input">Due date</label>
     <input type="date" id="due-date-input">
+    <label for="category-input">Category</label>
+    <input type="text" id="category-input" placeholder="Category">
     <label for="priority-select">Priority</label>
     <select id="priority-select">
       <option value="high">High</option>
@@ -50,6 +52,8 @@
       <option value="medium">Medium</option>
       <option value="low">Low</option>
     </select>
+    <label for="category-filter">Category</label>
+    <input type="text" id="category-filter" placeholder="All Categories">
     <label for="sort-select">Sort</label>
     <select id="sort-select">
       <option value="">No Sorting</option>

--- a/server.js
+++ b/server.js
@@ -128,13 +128,14 @@ app.get('/api/me', async (req, res) => {
 
 
 app.get('/api/tasks', requireAuth, async (req, res) => {
-  const { priority, done, sort } = req.query;
+  const { priority, done, sort, category } = req.query;
   try {
     const tasks = await db.listTasks({
       priority,
       done: done === 'true' ? true : done === 'false' ? false : undefined,
       sort,
-      userId: req.session.userId
+      userId: req.session.userId,
+      category
     });
     res.json(tasks);
   } catch (err) {
@@ -146,6 +147,7 @@ app.get('/api/tasks', requireAuth, async (req, res) => {
 app.post('/api/tasks', requireAuth, async (req, res) => {
   const text = req.body.text;
   const dueDate = req.body.dueDate;
+  const category = req.body.category;
   let priority = req.body.priority || 'medium';
   priority = ['high', 'medium', 'low'].includes(priority) ? priority : 'medium';
   if (!text) {
@@ -159,6 +161,7 @@ app.post('/api/tasks', requireAuth, async (req, res) => {
       text,
       dueDate,
       priority,
+      category,
       done: false,
       userId: req.session.userId
     });
@@ -171,7 +174,7 @@ app.post('/api/tasks', requireAuth, async (req, res) => {
 
 app.put('/api/tasks/:id', requireAuth, async (req, res) => {
   const id = parseInt(req.params.id);
-  const { text, dueDate, priority, done } = req.body;
+  const { text, dueDate, priority, done, category } = req.body;
   if (text !== undefined && !text.trim()) {
     return res.status(400).json({ error: 'Task text cannot be empty' });
   }
@@ -182,7 +185,7 @@ app.put('/api/tasks/:id', requireAuth, async (req, res) => {
     return res.status(400).json({ error: 'Invalid due date' });
   }
   try {
-    const updated = await db.updateTask(id, { text, dueDate, priority, done }, req.session.userId);
+    const updated = await db.updateTask(id, { text, dueDate, priority, done, category }, req.session.userId);
     if (!updated) {
       return res.status(404).json({ error: 'Task not found' });
     }

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -64,7 +64,7 @@ test('register user and CRUD tasks', async () => {
   res = await agent
     .post('/api/tasks')
     .set('CSRF-Token', token)
-    .send({ text: 'Test Task', priority: 'high', dueDate: '2099-12-31' });
+    .send({ text: 'Test Task', priority: 'high', dueDate: '2099-12-31', category: 'work' });
   expect(res.status).toBe(201);
   const taskId = res.body.id;
 
@@ -73,6 +73,12 @@ test('register user and CRUD tasks', async () => {
   expect(res.status).toBe(200);
   expect(res.body.length).toBe(1);
   expect(res.body[0].text).toBe('Test Task');
+  expect(res.body[0].category).toBe('work');
+
+  // filter by category
+  res = await agent.get('/api/tasks?category=work');
+  expect(res.status).toBe(200);
+  expect(res.body.length).toBe(1);
 
   // update task
   res = await agent


### PR DESCRIPTION
## Summary
- support optional `category` for tasks in database
- allow filtering tasks by category
- expose category in task CRUD API
- update frontend to capture and filter by category
- mention categories in README
- extend API tests for category logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686518f2caac8326a76c5cdb0e108810