### PR TITLE
Add search feature to task list

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is a simple Express-based task tracker.
 Tasks are persisted in a local SQLite database (`tasks.db`).
 Each user has their own task list after logging in. Tasks can optionally be assigned a category label so they can be filtered and grouped.
+You can also search your tasks by keyword using the search bar at the top of the task list or by sending a `search` query parameter to the `/api/tasks` endpoint.
 
 ## Installation
 

--- a/db.js
+++ b/db.js
@@ -33,7 +33,7 @@ db.serialize(() => {
   });
 });
 
-function listTasks({ priority, done, sort, userId, category } = {}) {
+function listTasks({ priority, done, sort, userId, category, search } = {}) {
   return new Promise((resolve, reject) => {
     let query = 'SELECT * FROM tasks';
     const where = [];
@@ -52,6 +52,11 @@ function listTasks({ priority, done, sort, userId, category } = {}) {
     if (category) {
       where.push('category = ?');
       params.push(category);
+    }
+
+    if (search) {
+      where.push('text LIKE ?');
+      params.push(`%${search}%`);
     }
 
     if (done === true || done === false) {

--- a/public/index.html
+++ b/public/index.html
@@ -54,6 +54,8 @@
     </select>
     <label for="category-filter">Category</label>
     <input type="text" id="category-filter" placeholder="All Categories">
+    <label for="search-input">Search</label>
+    <input type="text" id="search-input" placeholder="Keyword">
     <label for="sort-select">Sort</label>
     <select id="sort-select">
       <option value="">No Sorting</option>

--- a/public/script.js
+++ b/public/script.js
@@ -14,6 +14,9 @@ async function fetchTasks(filters = {}) {
   if (filters.sort) {
     params.append('sort', filters.sort);
   }
+  if (filters.search && filters.search.trim() !== '') {
+    params.append('search', filters.search.trim());
+  }
   const query = params.toString();
   const res = await fetch('/api/tasks' + (query ? `?${query}` : ''));
   return await res.json();
@@ -118,8 +121,9 @@ async function loadTasks() {
   const status = document.getElementById('status-filter').value;
   const priorityFilter = document.getElementById('priority-filter').value;
   const categoryFilter = document.getElementById('category-filter').value;
+  const search = document.getElementById('search-input').value;
   const sort = document.getElementById('sort-select').value;
-  const tasks = await fetchTasks({ status, priority: priorityFilter, category: categoryFilter, sort });
+  const tasks = await fetchTasks({ status, priority: priorityFilter, category: categoryFilter, sort, search });
   renderTasks(tasks);
 }
 
@@ -153,6 +157,7 @@ document.getElementById('status-filter').onchange = loadTasks;
 document.getElementById('priority-filter').onchange = loadTasks;
 document.getElementById('category-filter').onchange = loadTasks;
 document.getElementById('sort-select').onchange = loadTasks;
+document.getElementById('search-input').addEventListener('input', loadTasks);
 
 async function handleLogin(event) {
   if (event) event.preventDefault();

--- a/server.js
+++ b/server.js
@@ -128,14 +128,15 @@ app.get('/api/me', async (req, res) => {
 
 
 app.get('/api/tasks', requireAuth, async (req, res) => {
-  const { priority, done, sort, category } = req.query;
+  const { priority, done, sort, category, search } = req.query;
   try {
     const tasks = await db.listTasks({
       priority,
       done: done === 'true' ? true : done === 'false' ? false : undefined,
       sort,
       userId: req.session.userId,
-      category
+      category,
+      search
     });
     res.json(tasks);
   } catch (err) {

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -80,6 +80,11 @@ test('register user and CRUD tasks', async () => {
   expect(res.status).toBe(200);
   expect(res.body.length).toBe(1);
 
+  // search by keyword
+  res = await agent.get('/api/tasks?search=Test');
+  expect(res.status).toBe(200);
+  expect(res.body.length).toBe(1);
+
   // update task
   res = await agent
     .put(`/api/tasks/${taskId}`)


### PR DESCRIPTION
## Summary
- support `search` parameter in API and database queries
- add search bar in the frontend with filtering logic
- document search functionality in README
- test searching tasks via API

## Testing
- `npm test` *(fails: jest not found)*
- `node -e "require('./server')"` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68651bf641748326bbd4af56067dfcd4