### PR TITLE
Add subtask checklist feature

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -112,7 +112,54 @@ function renderTasks(tasks) {
       loadTasks();
     };
 
-    li.append(' ', toggleBtn, ' ', editBtn, ' ', deleteBtn);
+    const subList = document.createElement('ul');
+    if (Array.isArray(task.subtasks)) {
+      task.subtasks.forEach(sub => {
+        const subLi = document.createElement('li');
+        subLi.textContent = sub.text;
+        if (sub.done) subLi.classList.add('done');
+
+        const sToggle = document.createElement('button');
+        sToggle.textContent = sub.done ? 'Undo' : 'Done';
+        sToggle.onclick = async () => {
+          await fetch(`/api/subtasks/${sub.id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json', 'CSRF-Token': csrfToken },
+            body: JSON.stringify({ done: !sub.done })
+          });
+          loadTasks();
+        };
+
+        const sDelete = document.createElement('button');
+        sDelete.textContent = 'Delete';
+        sDelete.onclick = async () => {
+          await fetch(`/api/subtasks/${sub.id}`, {
+            method: 'DELETE',
+            headers: { 'CSRF-Token': csrfToken }
+          });
+          loadTasks();
+        };
+
+        subLi.append(' ', sToggle, ' ', sDelete);
+        subList.appendChild(subLi);
+      });
+    }
+
+    const addSubBtn = document.createElement('button');
+    addSubBtn.textContent = 'Add Step';
+    addSubBtn.onclick = async () => {
+      const text = prompt('Subtask text:');
+      if (!text) return;
+      await fetch(`/api/tasks/${task.id}/subtasks`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'CSRF-Token': csrfToken },
+        body: JSON.stringify({ text })
+      });
+      loadTasks();
+    };
+
+    li.append(' ', toggleBtn, ' ', editBtn, ' ', deleteBtn, ' ', addSubBtn);
+    li.appendChild(subList);
     list.appendChild(li);
   });
 }

--- a/public/style.css
+++ b/public/style.css
@@ -20,6 +20,11 @@ body {
   margin: 5px 0;
 }
 
+#task-list ul {
+  margin-left: 20px;
+  padding-left: 0;
+}
+
 .done {
   text-decoration: line-through;
   color: gray;

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -75,6 +75,19 @@ test('register user and CRUD tasks', async () => {
   expect(res.body[0].text).toBe('Test Task');
   expect(res.body[0].category).toBe('work');
 
+  // create subtask
+  res = await agent
+    .post(`/api/tasks/${taskId}/subtasks`)
+    .set('CSRF-Token', token)
+    .send({ text: 'Step 1' });
+  expect(res.status).toBe(201);
+  const subId = res.body.id;
+
+  // list subtasks
+  res = await agent.get(`/api/tasks/${taskId}/subtasks`);
+  expect(res.status).toBe(200);
+  expect(res.body.length).toBe(1);
+
   // filter by category
   res = await agent.get('/api/tasks?category=work');
   expect(res.status).toBe(200);
@@ -91,6 +104,19 @@ test('register user and CRUD tasks', async () => {
     .set('CSRF-Token', token)
     .send({ done: true });
   expect(res.body.done).toBe(true);
+
+  // update subtask
+  res = await agent
+    .put(`/api/subtasks/${subId}`)
+    .set('CSRF-Token', token)
+    .send({ done: true });
+  expect(res.body.done).toBe(true);
+
+  // delete subtask
+  res = await agent
+    .delete(`/api/subtasks/${subId}`)
+    .set('CSRF-Token', token);
+  expect(res.status).toBe(200);
 
   // delete task
   res = await agent


### PR DESCRIPTION
## Summary
- support subtasks in database and API
- expose subtask CRUD routes
- show subtasks in the UI with ability to add/toggle/delete
- style nested subtask list
- test subtask CRUD API

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651d6b9a1883269263dc7c2bb4eae9