### PR TITLE
Enable task assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 This is a simple Express-based task tracker.
 Tasks are persisted in a local SQLite database (`tasks.db`).
-Each user has their own task list after logging in. Tasks can optionally be assigned a category label so they can be filtered and grouped.
+Each user has their own task list after logging in. Tasks can optionally be assigned to another user as well as given a category label so they can be filtered and grouped.
 You can also search your tasks by keyword using the search bar at the top of the task list or by sending a `search` query parameter to the `/api/tasks` endpoint.
+
+Tasks can be assigned to another user using `POST /api/tasks/:id/assign` with a `username` in the request body. Assigned tasks will appear in that user's task list.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- support assigning tasks to other users
- expand task query functions to include assigned tasks
- add new `/api/tasks/:id/assign` route
- document task assignment feature in README
- test assigning tasks

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686520e73da48326a62c530605ed975c