### PR TITLE
Add due date reminder notifications

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
   <h1>Task Tracker</h1>
+  <ul id="notifications" style="display:none;"></ul>
     <div id="auth">
       <form id="login-form">
         <label for="username-input">Username</label>

--- a/public/style.css
+++ b/public/style.css
@@ -47,3 +47,10 @@ label {
   margin-right: 5px;
   display: inline-block;
 }
+
+#notifications {
+  margin-bottom: 10px;
+  list-style: none;
+  padding: 0;
+  color: blue;
+}

--- a/server.js
+++ b/server.js
@@ -145,6 +145,16 @@ app.get('/api/tasks', requireAuth, async (req, res) => {
   }
 });
 
+app.get('/api/reminders', requireAuth, async (req, res) => {
+  try {
+    const tasks = await db.getDueSoonTasks(req.session.userId);
+    res.json(tasks);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to load reminders' });
+  }
+});
+
 app.post('/api/tasks', requireAuth, async (req, res) => {
   const text = req.body.text;
   const dueDate = req.body.dueDate;


### PR DESCRIPTION
## Summary
- add `reminderSent` column and reminder utilities in db
- implement `/api/reminders` endpoint
- show due-date reminders in the frontend
- style and periodic loading of reminders

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686524b124408326964fa410cfc804b7