### PR TITLE
Add task import/export endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,15 @@ Automated tests are provided using Jest. Run them with:
 ```bash
 npm test
 ```
+
+## Import/Export
+
+Export all of your tasks in JSON or CSV format using:
+
+```
+GET /api/tasks/export?format=json|csv
+```
+
+Import tasks by sending a POST request to `/api/tasks/import`. Send a JSON array
+of task objects or CSV data (set `Content-Type: text/csv`). Imported tasks are
+added to the currently authenticated user's list.


### PR DESCRIPTION
## Summary
- implement CSV/JSON export and import endpoints
- add unit tests for import/export
- document new API capabilities

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652a75ebec8326af4d99f95906389b