### PR TITLE
Fix CSRF token retrieval on login

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -340,6 +340,7 @@ async function handleLogin(event) {
   const errorEl = document.getElementById('login-error');
   errorEl.textContent = '';
   if (username && password) {
+    await updateCsrfToken();
     const res = await fetch('/api/login', {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Summary
- ensure `handleLogin` fetches a new CSRF token before sending the login request

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865bb956cbc8326985bab5b191e0a1a