### PR TITLE
Implement basic admin roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Tasks can be assigned to another user using `POST /api/tasks/:id/assign` with a 
 You can also discuss tasks by adding comments using `POST /api/tasks/:taskId/comments` and view them with `GET /api/tasks/:taskId/comments`.
 Tasks may optionally repeat on a daily, weekly or monthly schedule by including a `repeatInterval` when creating them. Completing a repeating task automatically schedules the next occurrence.
 
+Users have roles of either `admin` or `member`. The first account created becomes the admin. Once an admin exists, only admins can create additional users, assign tasks or delete tasks.
+
 ## Installation
 
 Before starting the server, install dependencies:

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -157,9 +157,17 @@ test('assign task to another user', async () => {
     .set('CSRF-Token', token)
     .send({ username: 'alice', password: 'Passw0rd!' });
 
+  // register second user while logged in as admin alice
+  token = (await alice.get('/api/csrf-token')).body.csrfToken;
+  await alice
+    .post('/api/register')
+    .set('CSRF-Token', token)
+    .send({ username: 'bob', password: 'Passw0rd!' });
+
+  // bob logs in
   token = (await bob.get('/api/csrf-token')).body.csrfToken;
   await bob
-    .post('/api/register')
+    .post('/api/login')
     .set('CSRF-Token', token)
     .send({ username: 'bob', password: 'Passw0rd!' });
 


### PR DESCRIPTION
## Summary
- add role column to user table and migrate
- restrict registering new users, assigning tasks and deleting tasks to admins
- expose role in login and /api/me responses
- document roles in README
- update tests for admin registration flow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f7be1db08326b7ef30c1885bdbf2