### PR TITLE
Add notification preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,22 @@ Calling `GET /api/reminders` will send reminder emails for any tasks that are
 due or overdue. Tasks that remain incomplete will continue to trigger a reminder
 once per day until they are marked done.
 
+## Notification Preferences
+
+Each user can control whether they receive email reminders or notification
+emails for comments and task assignments. Retrieve your current settings with:
+
+```
+GET /api/preferences
+```
+
+Update them by sending:
+
+```
+PUT /api/preferences
+{ "emailReminders": false, "emailNotifications": true }
+```
+
 ## Attachments
 
 You can attach small files to tasks or comments by sending base64 encoded


### PR DESCRIPTION
## Summary
- allow users to opt out of reminder/notification emails
- store email preferences in the DB
- expose `/api/preferences` endpoints to get/update settings
- respect preferences when sending reminders, comment or assignment emails
- document new endpoints in README
- test email preference behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68670fa9734c83269dc34d2b5fe6d93c