### PR TITLE
Add Markdown rendering for tasks and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ GET /api/comments/:commentId/attachments
 GET /api/attachments/:id
 ```
 
+## Markdown Formatting
+
+Task text and comment bodies support basic Markdown formatting. When viewing
+tasks or comments in the web interface, any Markdown syntax will be rendered
+as HTML for improved readability.
+
+```
+**bold**, *italic*, `code`
+```
+
+Markdown is not processed on the server; raw text is stored and sanitized in the
+browser before being inserted into the page.
+
 ## Calendar View
 
 Open `calendar.html` in the `public` directory to see tasks on a monthly calendar. Use the Prev and Next buttons to navigate between months.

--- a/public/calendar.html
+++ b/public/calendar.html
@@ -32,6 +32,8 @@
   </div>
   <table id="calendar"></table>
 
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@2.4.0/dist/purify.min.js"></script>
   <script src="calendar.js"></script>
 </body>
 </html>

--- a/public/calendar.js
+++ b/public/calendar.js
@@ -79,7 +79,8 @@ function renderCalendar(year, month) {
         if (byDate[dateStr]) {
           byDate[dateStr].forEach(t => {
             const li = document.createElement('li');
-            li.textContent = t.text;
+            const html = DOMPurify.sanitize(marked.parse(t.text));
+            li.innerHTML = html;
             if (t.done) li.classList.add('done');
             list.appendChild(li);
           });

--- a/public/index.html
+++ b/public/index.html
@@ -78,6 +78,8 @@
   </div>
   <ul id="task-list"></ul>
 
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@2.4.0/dist/purify.min.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/public/script.js
+++ b/public/script.js
@@ -80,7 +80,8 @@ function renderTasks(tasks) {
     li.dataset.id = task.id;
     const cat = task.category ? ` {${task.category}}` : '';
     const textSpan = document.createElement('span');
-    textSpan.textContent = `${task.text} (Due: ${task.dueDate || 'N/A'}) [${task.priority}]${cat}`;
+    const taskHtml = DOMPurify.sanitize(marked.parse(task.text));
+    textSpan.innerHTML = `${taskHtml} (Due: ${task.dueDate || 'N/A'}) [${task.priority}]${cat}`;
     li.appendChild(textSpan);
     li.classList.add(task.priority);
     if (task.done) {
@@ -196,7 +197,8 @@ function renderTasks(tasks) {
     fetchComments(task.id).then(comments => {
       comments.forEach(c => {
         const cLi = document.createElement('li');
-        cLi.textContent = `${c.username}: ${c.text}`;
+        const commentHtml = DOMPurify.sanitize(marked.parse(c.text));
+        cLi.innerHTML = `<strong>${c.username}:</strong> ${commentHtml}`;
         if (currentUser && c.userId === currentUser.id) {
           const cDel = document.createElement('button');
           cDel.textContent = 'Delete';


### PR DESCRIPTION
## Summary
- show Markdown formatting in tasks and comments using `marked` and `DOMPurify`
- load Markdown libraries in HTML pages
- document Markdown formatting support in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671332a93483269ff9134de4454f12