### PR TITLE
Add team groups and shared tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,29 @@ PUT /api/preferences
 { "emailReminders": false, "emailNotifications": true }
 ```
 
+## Groups
+
+Create a team with:
+
+```
+POST /api/groups
+{ "name": "Team A" }
+```
+
+Join an existing group:
+
+```
+POST /api/groups/:id/join
+```
+
+List your groups:
+
+```
+GET /api/groups
+```
+
+When creating a task you can specify `groupId` so it is shared with all group members.
+
 ## Attachments
 
 You can attach small files to tasks or comments by sending base64 encoded


### PR DESCRIPTION
## Summary
- support groups and membership in the database
- allow creating/joining groups via new API endpoints
- add optional `groupId` when creating tasks
- show user how to use group endpoints in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671435e4c48326be25cbd5515d8ffe