### PR TITLE
Add pagination to tasks API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a simple Express-based task tracker.
 Tasks are persisted in a local SQLite database (`tasks.db`).
 Each user has their own task list after logging in. Tasks can optionally be assigned to another user as well as given a category label so they can be filtered and grouped.
 You can also search your tasks by keyword across both task text and comments using the search bar or by sending a `search` query parameter to the `/api/tasks` endpoint. The task list endpoint additionally supports filtering by multiple categories with the `categories` query parameter and limiting results to a due date range via `startDate` and `endDate`.
+Results can be paginated with `page` and `pageSize` query parameters to more easily navigate large task lists.
 
 Tasks can be assigned to another user using `POST /api/tasks/:id/assign` with a `username` in the request body. Assigned tasks will appear in that user's task list.
 You can also discuss tasks by adding comments using `POST /api/tasks/:taskId/comments` and view them with `GET /api/tasks/:taskId/comments`.

--- a/db.js
+++ b/db.js
@@ -152,7 +152,9 @@ function listTasks({
   categories,
   search,
   startDate,
-  endDate
+  endDate,
+  limit,
+  offset
 } = {}) {
   return new Promise((resolve, reject) => {
     let query =
@@ -209,6 +211,11 @@ function listTasks({
     } else if (sort === 'priority') {
       query +=
         " ORDER BY CASE priority WHEN 'high' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END";
+    }
+
+    if (limit !== undefined) {
+      query += ' LIMIT ? OFFSET ?';
+      params.push(limit, offset || 0);
     }
 
     db.all(query, params, async (err, rows) => {

--- a/server.js
+++ b/server.js
@@ -301,7 +301,9 @@ app.get('/api/groups', requireAuth, async (req, res) => {
 
 
 app.get('/api/tasks', requireAuth, async (req, res) => {
-  const { priority, done, sort, category, categories, search, startDate, endDate } = req.query;
+  const { priority, done, sort, category, categories, search, startDate, endDate, page, pageSize } = req.query;
+  const pg = parseInt(page, 10) >= 1 ? parseInt(page, 10) : 1;
+  const size = parseInt(pageSize, 10) >= 1 ? parseInt(pageSize, 10) : 20;
   try {
     const tasks = await db.listTasks({
       priority,
@@ -317,7 +319,9 @@ app.get('/api/tasks', requireAuth, async (req, res) => {
         : undefined,
       search,
       startDate,
-      endDate
+      endDate,
+      limit: size,
+      offset: (pg - 1) * size
     });
     res.json(tasks);
   } catch (err) {

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -637,3 +637,29 @@ test('task dependencies enforcement', async () => {
   expect(res.body.done).toBe(true);
 });
 
+test('tasks endpoint supports pagination', async () => {
+  const agent = request.agent(app);
+
+  let token = (await agent.get('/api/csrf-token')).body.csrfToken;
+  await agent
+    .post('/api/register')
+    .set('CSRF-Token', token)
+    .send({ username: 'pager', password: 'Passw0rd!' });
+
+  for (let i = 0; i < 3; i++) {
+    token = (await agent.get('/api/csrf-token')).body.csrfToken;
+    await agent
+      .post('/api/tasks')
+      .set('CSRF-Token', token)
+      .send({ text: `Task ${i}` });
+  }
+
+  let res = await agent.get('/api/tasks?page=1&pageSize=2');
+  expect(res.status).toBe(200);
+  expect(res.body.length).toBe(2);
+
+  res = await agent.get('/api/tasks?page=2&pageSize=2');
+  expect(res.status).toBe(200);
+  expect(res.body.length).toBe(1);
+});
+


### PR DESCRIPTION
## Summary
- add `page` and `pageSize` parameters to `/api/tasks`
- support pagination inside DB query
- document pagination in README
- test pagination in API tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671631dc4083268a3bdb393f998b4e