### PR TITLE
Add OAuth login via Google and GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ and `password`. Log in via `/api/login` and log out with `/api/logout`. The
 frontend includes a simple form for these actions. Tasks are only accessible
 when logged in.
 
+If Google or GitHub OAuth credentials are configured via environment variables
+(`GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` and `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET`),
+you can also log in using those providers from the login screen.
+
 Passwords must be at least 8 characters long and include upper and lower case
 letters and a number.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "sqlite3": "^5.1.6",
     "express-session": "^1.17.3",
     "bcryptjs": "^2.4.3",
-    "csurf": "^1.11.0"
+    "csurf": "^1.11.0",
+    "passport": "^0.6.0",
+    "passport-google-oauth20": "^2.0.0",
+    "passport-github2": "^0.1.12"
   },
   "devDependencies": {
     "jest": "^29.6.1",

--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,8 @@
         <input type="password" id="password-input" placeholder="Password" autocomplete="current-password" required>
         <button id="login-button" type="submit">Login</button>
         <button id="register-button" type="button">Register</button>
+        <button id="google-login" type="button">Login with Google</button>
+        <button id="github-login" type="button">Login with GitHub</button>
         <div id="login-error" class="error" aria-live="polite"></div>
       </form>
       <div id="user-info" style="display:none;">

--- a/public/script.js
+++ b/public/script.js
@@ -368,6 +368,10 @@ async function handleLogin(event) {
 
 document.getElementById('login-button').onclick = handleLogin;
 document.getElementById('login-form').addEventListener('submit', handleLogin);
+const googleBtn = document.getElementById('google-login');
+if (googleBtn) googleBtn.onclick = () => (window.location.href = '/auth/google');
+const githubBtn = document.getElementById('github-login');
+if (githubBtn) githubBtn.onclick = () => (window.location.href = '/auth/github');
 
 document.getElementById('register-button').onclick = async () => {
   const username = document.getElementById('username-input').value.trim();

--- a/server.js
+++ b/server.js
@@ -8,6 +8,27 @@ const crypto = require('crypto');
 const csurf = require('csurf');
 const totp = require('./totp');
 const email = require('./email');
+let passport;
+let GoogleStrategy;
+let GitHubStrategy;
+const enableGoogle =
+  process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET;
+const enableGithub =
+  process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET;
+if (enableGoogle || enableGithub) {
+  try {
+    passport = require('passport');
+    if (enableGoogle) {
+      GoogleStrategy = require('passport-google-oauth20').Strategy;
+    }
+    if (enableGithub) {
+      GitHubStrategy = require('passport-github2').Strategy;
+    }
+  } catch (err) {
+    console.warn('Passport modules not installed; OAuth disabled');
+    passport = null;
+  }
+}
 const app = express();
 
 // Use a higher bcrypt work factor for stronger password hashing.
@@ -56,8 +77,126 @@ app.use(
     }
   })
 );
+if (passport) {
+  app.use(passport.initialize());
+  app.use(passport.session());
+
+  passport.serializeUser((user, done) => done(null, user.id));
+  passport.deserializeUser(async (id, done) => {
+    try {
+      const user = await db.getUserById(id);
+      done(null, user);
+    } catch (err) {
+      done(err);
+    }
+  });
+}
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(csurf());
+
+if (passport) {
+  if (enableGoogle) {
+    passport.use(
+      new GoogleStrategy(
+        {
+          clientID: process.env.GOOGLE_CLIENT_ID,
+          clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+          callbackURL: '/auth/google/callback'
+        },
+        async (accessToken, refreshToken, profile, done) => {
+          try {
+            let user = await db.getUserByGoogleId(profile.id);
+            if (!user) {
+              const username =
+                (profile.emails && profile.emails[0] && profile.emails[0].value) ||
+                `google_${profile.id}`;
+              user = await db.getUserByUsername(username);
+              if (user) {
+                await db.setUserGoogleId(user.id, profile.id);
+              } else {
+                const count = await db.countUsers();
+                const role = count === 0 ? 'admin' : 'member';
+                const hash = await bcrypt.hash(
+                  crypto.randomBytes(16).toString('hex'),
+                  BCRYPT_ROUNDS
+                );
+                user = await db.createUser({
+                  username,
+                  password: hash,
+                  role,
+                  googleId: profile.id
+                });
+              }
+            }
+            done(null, user);
+          } catch (err) {
+            done(err);
+          }
+        }
+      )
+    );
+
+    app.get('/auth/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+    app.get(
+      '/auth/google/callback',
+      passport.authenticate('google', { failureRedirect: '/' }),
+      (req, res) => {
+        req.session.userId = req.user.id;
+        res.redirect('/');
+      }
+    );
+  }
+
+  if (enableGithub) {
+    passport.use(
+      new GitHubStrategy(
+        {
+          clientID: process.env.GITHUB_CLIENT_ID,
+          clientSecret: process.env.GITHUB_CLIENT_SECRET,
+          callbackURL: '/auth/github/callback'
+        },
+        async (accessToken, refreshToken, profile, done) => {
+          try {
+            let user = await db.getUserByGithubId(profile.id);
+            if (!user) {
+              const username = profile.username || `github_${profile.id}`;
+              user = await db.getUserByUsername(username);
+              if (user) {
+                await db.setUserGithubId(user.id, profile.id);
+              } else {
+                const count = await db.countUsers();
+                const role = count === 0 ? 'admin' : 'member';
+                const hash = await bcrypt.hash(
+                  crypto.randomBytes(16).toString('hex'),
+                  BCRYPT_ROUNDS
+                );
+                user = await db.createUser({
+                  username,
+                  password: hash,
+                  role,
+                  githubId: profile.id
+                });
+              }
+            }
+            done(null, user);
+          } catch (err) {
+            done(err);
+          }
+        }
+      )
+    );
+
+    app.get('/auth/github', passport.authenticate('github', { scope: ['user:email'] }));
+    app.get(
+      '/auth/github/callback',
+      passport.authenticate('github', { failureRedirect: '/' }),
+      (req, res) => {
+        req.session.userId = req.user.id;
+        res.redirect('/');
+      }
+    );
+  }
+}
 
 app.get('/api/csrf-token', (req, res) => {
   res.json({ csrfToken: req.csrfToken() });


### PR DESCRIPTION
## Summary
- allow OAuth sign in via Google and GitHub when credentials are configured
- store provider ids in DB and expose helper methods
- update README with OAuth usage notes
- add login buttons to frontend and handler logic
- conditionally load passport dependencies if environment variables are present

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671848e03c8326b2eaa2be5800734f