### PR TITLE
Add due time support for tasks

### DIFF
--- a/db.js
+++ b/db.js
@@ -22,6 +22,7 @@ db.serialize(() => {
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     text TEXT NOT NULL,
     dueDate TEXT,
+    dueTime TEXT,
     priority TEXT NOT NULL,
     done INTEGER NOT NULL DEFAULT 0,
     userId INTEGER,
@@ -116,6 +117,9 @@ db.serialize(() => {
     }
     if (!cols.some(c => c.name === 'groupId')) {
       db.run('ALTER TABLE tasks ADD COLUMN groupId INTEGER');
+    }
+    if (!cols.some(c => c.name === 'dueTime')) {
+      db.run('ALTER TABLE tasks ADD COLUMN dueTime TEXT');
     }
     if (!cols.some(c => c.name === 'reminderSent')) {
       db.run('ALTER TABLE tasks ADD COLUMN reminderSent INTEGER NOT NULL DEFAULT 0');
@@ -241,14 +245,14 @@ function listTasks({
   });
 }
 
-function createTask({ text, dueDate, priority = 'medium', done = false, userId, category, assignedTo, groupId, repeatInterval }) {
+function createTask({ text, dueDate, dueTime, priority = 'medium', done = false, userId, category, assignedTo, groupId, repeatInterval }) {
   return new Promise((resolve, reject) => {
     db.run(
-      `INSERT INTO tasks (text, dueDate, priority, done, userId, category, assignedTo, groupId, reminderSent, lastReminderDate, repeatInterval) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?)`,
-      [text, dueDate, priority, done ? 1 : 0, userId, category, assignedTo, groupId, repeatInterval],
+      `INSERT INTO tasks (text, dueDate, dueTime, priority, done, userId, category, assignedTo, groupId, reminderSent, lastReminderDate, repeatInterval) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?)`,
+      [text, dueDate, dueTime, priority, done ? 1 : 0, userId, category, assignedTo, groupId, repeatInterval],
       function (err) {
         if (err) return reject(err);
-        resolve({ id: this.lastID, text, dueDate, priority, done, userId, category, assignedTo, groupId, repeatInterval, lastReminderDate: null });
+        resolve({ id: this.lastID, text, dueDate, dueTime, priority, done, userId, category, assignedTo, groupId, repeatInterval, lastReminderDate: null });
       }
     );
   });
@@ -280,6 +284,12 @@ function updateTask(id, fields, userId) {
     if (fields.dueDate !== undefined) {
       updates.push('dueDate = ?');
       params.push(fields.dueDate);
+      updates.push('reminderSent = 0');
+      updates.push('lastReminderDate = NULL');
+    }
+    if (fields.dueTime !== undefined) {
+      updates.push('dueTime = ?');
+      params.push(fields.dueTime);
       updates.push('reminderSent = 0');
       updates.push('lastReminderDate = NULL');
     }
@@ -837,12 +847,12 @@ function setUserGithubId(id, githubId) {
 
 function getDueSoonTasks(userId) {
   return new Promise((resolve, reject) => {
-    const today = new Date();
-    today.setUTCHours(0, 0, 0, 0);
-    const limit = today.toISOString().slice(0, 10);
-    const params = [limit, userId, userId, userId, limit];
+    const now = new Date();
+    const dateStr = now.toISOString().slice(0, 10);
+    const timeStr = now.toISOString().slice(11, 16);
+    const params = [dateStr, dateStr, timeStr, userId, userId, userId, dateStr];
     const sql =
-      'SELECT * FROM tasks WHERE dueDate IS NOT NULL AND dueDate <= ? AND done = 0 AND (userId = ? OR assignedTo = ? OR groupId IN (SELECT groupId FROM group_members WHERE userId = ?)) AND (lastReminderDate IS NULL OR lastReminderDate < ?)';
+      'SELECT * FROM tasks WHERE dueDate IS NOT NULL AND done = 0 AND (dueDate < ? OR (dueDate = ? AND (dueTime IS NULL OR dueTime <= ?))) AND (userId = ? OR assignedTo = ? OR groupId IN (SELECT groupId FROM group_members WHERE userId = ?)) AND (lastReminderDate IS NULL OR lastReminderDate < ?)';
     db.all(sql, params, (err, rows) => {
       if (err) return reject(err);
       if (!rows || rows.length === 0) return resolve([]);
@@ -850,7 +860,7 @@ function getDueSoonTasks(userId) {
       const placeholders = ids.map(() => '?').join(',');
       db.run(
         `UPDATE tasks SET lastReminderDate = ? WHERE id IN (${placeholders})`,
-        [limit, ...ids],
+        [dateStr, ...ids],
         err2 => {
           if (err2) return reject(err2);
           resolve(rows);

--- a/public/calendar.js
+++ b/public/calendar.js
@@ -106,7 +106,8 @@ async function loadReminders() {
     container.style.display = 'block';
     reminders.forEach(r => {
       const li = document.createElement('li');
-      li.textContent = `Reminder: "${r.text}" due ${r.dueDate}`;
+      const due = r.dueTime ? `${r.dueDate} ${r.dueTime}` : r.dueDate;
+      li.textContent = `Reminder: "${r.text}" due ${due}`;
       container.appendChild(li);
     });
   } else {

--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,8 @@
     <input type="text" id="task-input" placeholder="New task">
     <label for="due-date-input">Due date</label>
     <input type="date" id="due-date-input">
+    <label for="due-time-input">Due time</label>
+    <input type="time" id="due-time-input">
     <label for="category-input">Category</label>
     <input type="text" id="category-input" placeholder="Category">
     <label for="priority-select">Priority</label>

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -65,11 +65,18 @@ test('register user and CRUD tasks', async () => {
     .send({ text: 'Bad', dueDate: '2020/01/01' });
   expect(res.status).toBe(400);
 
+  // invalid due time
+  res = await agent
+    .post('/api/tasks')
+    .set('CSRF-Token', token)
+    .send({ text: 'BadTime', dueDate: '2099-01-01', dueTime: '25:00' });
+  expect(res.status).toBe(400);
+
   // create task
   res = await agent
     .post('/api/tasks')
     .set('CSRF-Token', token)
-    .send({ text: 'Test Task', priority: 'high', dueDate: '2099-12-31', category: 'work' });
+    .send({ text: 'Test Task', priority: 'high', dueDate: '2099-12-31', dueTime: '12:30', category: 'work' });
   expect(res.status).toBe(201);
   const taskId = res.body.id;
 
@@ -79,6 +86,7 @@ test('register user and CRUD tasks', async () => {
   expect(res.body.length).toBe(1);
   expect(res.body[0].text).toBe('Test Task');
   expect(res.body[0].category).toBe('work');
+  expect(res.body[0].dueTime).toBe('12:30');
 
   // create subtask
   res = await agent


### PR DESCRIPTION
## Summary
- allow storing an optional `dueTime` for tasks
- validate due time input and handle date+time comparisons
- include due time in reminders, SSE events and CSV import/export
- add time picker to the UI and handle due time in the frontend scripts
- test due time creation and validation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68675886de408326a4729182e365c179