### PR TITLE
Add admin task reports

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -12,6 +12,8 @@
   <div id="admin-content" style="display:none;">
     <h2>System Statistics</h2>
     <pre id="stats"></pre>
+    <h2>Reports</h2>
+    <pre id="reports"></pre>
     <h2>Users</h2>
     <ul id="user-list"></ul>
     <h2>Activity Logs</h2>

--- a/public/admin.js
+++ b/public/admin.js
@@ -14,6 +14,7 @@ async function init() {
   }
   document.getElementById('admin-content').style.display = 'block';
   loadStats();
+  loadReports();
   loadUsers();
   loadLogs();
 }
@@ -23,6 +24,14 @@ async function loadStats() {
   if (res.ok) {
     const stats = await res.json();
     document.getElementById('stats').textContent = JSON.stringify(stats, null, 2);
+  }
+}
+
+async function loadReports() {
+  const res = await fetch('/api/admin/reports');
+  if (res.ok) {
+    const reports = await res.json();
+    document.getElementById('reports').textContent = JSON.stringify(reports, null, 2);
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -485,6 +485,16 @@ app.get('/api/admin/stats', requireAdmin, async (req, res) => {
   }
 });
 
+app.get('/api/admin/reports', requireAdmin, async (req, res) => {
+  try {
+    const reports = await db.getReports();
+    res.json(reports);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to load reports' });
+  }
+});
+
 app.get('/api/preferences', requireAuth, async (req, res) => {
   try {
     const user = await db.getUserById(req.session.userId);
@@ -934,6 +944,12 @@ app.put('/api/tasks/:id', requireAuth, async (req, res) => {
       details: null
     });
     if (oldTask && !oldTask.done && updated.done) {
+      await db.createHistory({
+        taskId: updated.id,
+        userId: req.session.userId,
+        action: 'completed',
+        details: null
+      });
       await webhooks.sendWebhook('task_completed', {
         taskId: updated.id,
         text: updated.text

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -729,6 +729,10 @@ test('admin endpoints require admin role', async () => {
   res = await adminAgent.get('/api/admin/stats');
   expect(res.status).toBe(200);
   expect(res.body.users).toBeDefined();
+
+  res = await adminAgent.get('/api/admin/reports');
+  expect(res.status).toBe(200);
+  expect(res.body.overdue).toBeDefined();
 });
 
 test('webhooks triggered on task actions', async () => {


### PR DESCRIPTION
## Summary
- collect task completion events in history table
- provide `/api/admin/reports` endpoint with overdue counts and weekly completion counts
- update admin dashboard HTML/JS to display new reports
- extend tests for new endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68675ceafc588326898f10f22b393e83