### PR TITLE
Add offline support with service worker

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -21,5 +21,6 @@
   </div>
   <div id="not-admin" class="error" style="display:none;">Access denied</div>
   <script src="admin.js"></script>
+  <script src="sw-register.js"></script>
 </body>
 </html>

--- a/public/board.html
+++ b/public/board.html
@@ -59,5 +59,6 @@
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@2.4.0/dist/purify.min.js"></script>
   <script src="board.js"></script>
+  <script src="sw-register.js"></script>
 </body>
 </html>

--- a/public/calendar.html
+++ b/public/calendar.html
@@ -35,5 +35,6 @@
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@2.4.0/dist/purify.min.js"></script>
   <script src="calendar.js"></script>
+  <script src="sw-register.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -87,5 +87,6 @@
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@2.4.0/dist/purify.min.js"></script>
   <script src="script.js"></script>
+  <script src="sw-register.js"></script>
 </body>
 </html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,114 @@
+const CACHE_NAME = 'tasktracker-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/board.html',
+  '/calendar.html',
+  '/admin.html',
+  '/style.css',
+  '/script.js',
+  '/board.js',
+  '/calendar.js',
+  '/admin.js',
+  '/sw-register.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(clients.claim());
+});
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('task-queue', 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore('requests', { autoIncrement: true });
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function storeRequest(data) {
+  return openDB().then(db => {
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction('requests', 'readwrite');
+      tx.objectStore('requests').add(data);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  });
+}
+
+async function flushQueue() {
+  const db = await openDB();
+  const tx = db.transaction('requests', 'readwrite');
+  const store = tx.objectStore('requests');
+  const all = await new Promise((resolve, reject) => {
+    const get = store.getAll();
+    get.onsuccess = () => resolve(get.result || []);
+    get.onerror = () => reject(get.error);
+  });
+  for (const r of all) {
+    try {
+      await fetch(r.url, {
+        method: r.method,
+        headers: r.headers,
+        body: r.body ? JSON.stringify(r.body) : undefined
+      });
+    } catch (err) {
+      // stop if network fails
+      return;
+    }
+  }
+  store.clear();
+  return tx.complete;
+}
+
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  if (event.request.method === 'GET' && ASSETS.includes(url.pathname)) {
+    event.respondWith(
+      caches.match(event.request).then(res => res || fetch(event.request))
+    );
+    return;
+  }
+  if (url.pathname.startsWith('/api/') && event.request.method !== 'GET') {
+    event.respondWith(
+      fetch(event.request.clone()).catch(async () => {
+        const headers = {};
+        for (const [k, v] of event.request.headers.entries()) {
+          headers[k] = v;
+        }
+        let body = null;
+        try {
+          body = await event.request.clone().json();
+        } catch (e) {
+          body = await event.request.clone().text();
+        }
+        await storeRequest({
+          url: url.pathname + url.search,
+          method: event.request.method,
+          headers,
+          body
+        });
+        return new Response(JSON.stringify({ queued: true }), {
+          status: 202,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      })
+    );
+  }
+});
+
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'flush') {
+    event.waitUntil(flushQueue());
+  }
+});

--- a/public/sw-register.js
+++ b/public/sw-register.js
@@ -1,0 +1,14 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('service-worker.js').then(() => {
+      if (navigator.serviceWorker.controller) {
+        navigator.serviceWorker.controller.postMessage({ type: 'flush' });
+      }
+    });
+  });
+  window.addEventListener('online', () => {
+    if (navigator.serviceWorker.controller) {
+      navigator.serviceWorker.controller.postMessage({ type: 'flush' });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- implement new `service-worker.js` that caches assets and queues API requests when offline
- add `sw-register.js` helper to register the service worker and flush requests when online
- register the service worker from all HTML pages

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68675fa934248326995f6398829f7938