### PR TITLE
Improve ICS export with task status and priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ GET /api/tasks/ics
 ```
 
 The endpoint returns a standard `.ics` file that can be imported into clients
-like Google Calendar so your tasks appear alongside other events.
+like Google Calendar so your tasks appear alongside other events. Each entry now
+includes `PRIORITY` and `STATUS` fields so you can see task importance and
+whether it has been completed directly in your calendar.
 
 ## Webhooks
 

--- a/server.js
+++ b/server.js
@@ -694,6 +694,11 @@ function toIcs(tasks) {
     } else if (t.dueDate) {
       lines.push('DUE;VALUE=DATE:' + t.dueDate.replace(/-/g, ''));
     }
+    if (t.priority) {
+      const p = t.priority === 'high' ? 1 : t.priority === 'medium' ? 5 : 9;
+      lines.push('PRIORITY:' + p);
+    }
+    lines.push('STATUS:' + (t.done ? 'COMPLETED' : 'NEEDS-ACTION'));
     lines.push('SUMMARY:' + (t.text || '').replace(/\r?\n/g, ' '));
     lines.push('END:VTODO');
   }


### PR DESCRIPTION
## Summary
- include PRIORITY and STATUS fields in ICS feed
- mention new ICS info in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a1737dd448326ad77768ef3924578