### PR TITLE
Clarify test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,26 @@ endpoint before sending another state-changing request.
 
 ## Testing
 
-Automated tests are provided using Jest. Run them with:
+Automated tests are provided using Jest. Make sure all dependencies, including
+the Jest test runner, are installed first:
+
+```bash
+npm install
+```
+
+Run the suite with:
 
 ```bash
 npm test
+```
+
+Jest is listed in `package.json` under `devDependencies`:
+
+```json
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
+  }
 ```
 
 ## Import/Export


### PR DESCRIPTION
## Summary
- document running `npm install` so that Jest is available for `npm test`
- include snippet showing Jest in devDependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c586f29b0832695601a228e566f1a