### PR TITLE
Add OAuth module warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ when logged in.
 
 If Google or GitHub OAuth credentials are configured via environment variables
 (`GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` and `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET`),
-you can also log in using those providers from the login screen.
+you can also log in using those providers from the login screen. The server only
+initializes the required Passport strategies when these variables are present.
+If the optional `passport`, `passport-google-oauth20` or `passport-github2`
+modules are missing, a warning is logged at startup and the OAuth routes will be
+unavailable.
 
 Passwords must be at least 8 characters long and include upper and lower case
 letters and a number.

--- a/server.js
+++ b/server.js
@@ -13,10 +13,12 @@ const webhooks = require('./webhooks');
 let passport;
 let GoogleStrategy;
 let GitHubStrategy;
-const enableGoogle =
-  process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET;
-const enableGithub =
-  process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET;
+const enableGoogle = Boolean(
+  process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET
+);
+const enableGithub = Boolean(
+  process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET
+);
 if (enableGoogle || enableGithub) {
   try {
     passport = require('passport');
@@ -30,6 +32,8 @@ if (enableGoogle || enableGithub) {
     console.warn('Passport modules not installed; OAuth disabled');
     passport = null;
   }
+} else {
+  console.warn('OAuth environment variables not set; skipping Passport initialization');
 }
 const app = express();
 


### PR DESCRIPTION
## Summary
- clarify that OAuth modules are optional in README
- log when OAuth environment variables are missing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c5c49a25c8326b309281886209380