### PR TITLE
Make reminder check interval configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ npm start
 The server will run on port 3000 by default if no `PORT` variable is set.
 You can configure the bcrypt work factor with the `BCRYPT_ROUNDS` environment
 variable (default `12`). Higher values provide stronger hashing but increase CPU
-usage.
+usage. The frequency of automatic reminder checks can be changed with the
+`DUE_SOON_CHECK_INTERVAL` environment variable (milliseconds, default `60000`).
 
 ## Authentication
 

--- a/server.js
+++ b/server.js
@@ -101,7 +101,9 @@ async function checkDueSoon() {
   }
 }
 
-setInterval(checkDueSoon, 60000);
+const DUE_SOON_CHECK_INTERVAL =
+  parseInt(process.env.DUE_SOON_CHECK_INTERVAL, 10) || 60000;
+setInterval(checkDueSoon, DUE_SOON_CHECK_INTERVAL);
 
 // Use a higher bcrypt work factor for stronger password hashing.
 // Configurable via the BCRYPT_ROUNDS environment variable.


### PR DESCRIPTION
## Summary
- add `DUE_SOON_CHECK_INTERVAL` env var
- document configurable reminder interval in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c64b1b4408326ad694407e29abcf2