### PR TITLE
Add indexes to speed up task queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ npm install
 
 This will install `sqlite3` which is used for persistence. The database file
 `tasks.db` will be created automatically on first run.
+Indexes on the `dueDate`, `userId` and `assignedTo` columns are created to keep
+common task queries fast.
 Session data is also stored in this database so it survives server restarts.
 Session cookies are configured with `httpOnly`, `sameSite=lax` and
 `secure` (enabled when `NODE_ENV` is set to `production`) to help protect

--- a/db.js
+++ b/db.js
@@ -110,6 +110,11 @@ db.serialize(() => {
     FOREIGN KEY(userId) REFERENCES users(id) ON DELETE CASCADE
   )`);
 
+  // Add indexes to speed up common queries
+  db.run('CREATE INDEX IF NOT EXISTS idx_tasks_dueDate ON tasks(dueDate)');
+  db.run('CREATE INDEX IF NOT EXISTS idx_tasks_userId ON tasks(userId)');
+  db.run('CREATE INDEX IF NOT EXISTS idx_tasks_assignedTo ON tasks(assignedTo)');
+
   db.all("PRAGMA table_info(tasks)", (err, cols) => {
     if (err) return;
     if (!cols.some(c => c.name === 'userId')) {


### PR DESCRIPTION
## Summary
- add sqlite indexes on dueDate, userId and assignedTo
- document new indexes in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c6ab6c2608326ad3539e01dff1f55