### PR TITLE
Implement tagging with color labels

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,8 @@
     <input type="time" id="due-time-input">
     <label for="category-input">Category</label>
     <input type="text" id="category-input" placeholder="Category">
+    <label for="tags-input">Tags</label>
+    <input type="text" id="tags-input" placeholder="tag1,tag2">
     <label for="priority-select">Priority</label>
     <select id="priority-select">
       <option value="high">High</option>
@@ -68,6 +70,8 @@
     </select>
     <label for="category-filter">Category</label>
     <input type="text" id="category-filter" placeholder="All Categories">
+    <label for="tags-filter">Tags</label>
+    <input type="text" id="tags-filter" placeholder="tag">
     <label for="search-input">Search</label>
     <input type="text" id="search-input" placeholder="Keyword">
     <label for="sort-select">Sort</label>

--- a/public/style.css
+++ b/public/style.css
@@ -178,3 +178,12 @@ label {
   margin-top: 10px;
   margin-bottom: 10px;
 }
+
+.tag {
+  display: inline-block;
+  padding: 2px 4px;
+  margin-left: 4px;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.8em;
+}

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -209,6 +209,36 @@ test('advanced filtering', async () => {
   expect(res.body[0].id).toBe(id2);
 });
 
+test('filter by tags', async () => {
+  const agent = request.agent(app);
+
+  let token = (await agent.get('/api/csrf-token')).body.csrfToken;
+  await agent
+    .post('/api/register')
+    .set('CSRF-Token', token)
+    .send({ username: 'taguser', password: 'Passw0rd!' });
+
+  token = (await agent.get('/api/csrf-token')).body.csrfToken;
+  await agent
+    .post('/api/tasks')
+    .set('CSRF-Token', token)
+    .send({ text: 'T1', tags: ['a', 'b'] });
+
+  token = (await agent.get('/api/csrf-token')).body.csrfToken;
+  await agent
+    .post('/api/tasks')
+    .set('CSRF-Token', token)
+    .send({ text: 'T2', tags: ['b'] });
+
+  let res = await agent.get('/api/tasks?tags=a');
+  expect(res.body.length).toBe(1);
+  expect(res.body[0].text).toBe('T1');
+
+  res = await agent.get('/api/tasks?tags=a,b');
+  expect(res.body.length).toBe(1);
+  expect(res.body[0].text).toBe('T1');
+});
+
 test('assign task to another user', async () => {
   const alice = request.agent(app);
   const bob = request.agent(app);


### PR DESCRIPTION
## Summary
- add `tags` column and helpers in db layer
- support tags in tasks API for list/create/update/import/export
- display colored tag labels in UI and allow filtering
- add tag inputs in task form and filtering controls
- style `.tag` labels
- cover tag filtering with new tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cbc462de88326b338068b449d3a27