### PR TITLE
Add group admin and observer roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tasks can be assigned to another user using `POST /api/tasks/:id/assign` with a 
 You can also discuss tasks by adding comments using `POST /api/tasks/:taskId/comments` and view them with `GET /api/tasks/:taskId/comments`.
 Tasks may optionally repeat on a daily, weekly, monthly, weekday or last-day schedule by including a `repeatInterval` when creating them. Completing a repeating task automatically schedules the next occurrence.
 
-Users have roles of either `admin` or `member`. The first account created becomes the admin. Once an admin exists, only admins can create additional users, assign tasks or delete tasks.
+Users have roles of `admin`, `group_admin`, `member` or `observer`. The first account created becomes the admin. Only admins can create additional users and may specify any of the roles when doing so. Observers cannot modify tasks and group creation is limited to admins or group admins.
 For a full list of endpoints see the [API reference](docs/api-reference.md) and the machine-readable [OpenAPI specification](docs/openapi.yaml).
 
 ## Installation

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -23,6 +23,9 @@ paths:
                   type: string
                 password:
                   type: string
+                role:
+                  type: string
+                  description: Optional role when created by an admin
               required:
                 - username
                 - password
@@ -189,6 +192,11 @@ components:
           type: string
         role:
           type: string
+          enum:
+            - admin
+            - group_admin
+            - member
+            - observer
     Task:
       type: object
       properties:

--- a/public/script.js
+++ b/public/script.js
@@ -92,6 +92,11 @@ async function checkAuth() {
     taskForm.style.display = 'block';
     controls.style.display = 'block';
     bulkControls.style.display = 'block';
+    if (currentUser.role === 'observer') {
+      taskForm.style.display = 'none';
+      controls.style.display = 'none';
+      bulkControls.style.display = 'none';
+    }
     if (currentUser.role === 'admin') adminLink.style.display = 'inline';
     else adminLink.style.display = 'none';
     loadTasks();


### PR DESCRIPTION
## Summary
- add new `group_admin` and `observer` roles
- block observers from modifying data via new middleware
- allow admins to specify a role when registering users
- limit group creation to admins or group admins
- document roles in README and OpenAPI spec
- test observer and group admin permissions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cded6aad48326ac25caa558b0298e