### PR TITLE
Add ICS import functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,9 @@ GET /api/tasks/export?format=json|csv
 ```
 
 Import tasks by sending a POST request to `/api/tasks/import`. Send a JSON array
-of task objects or CSV data (set `Content-Type: text/csv`). Imported tasks are
-added to the currently authenticated user's list.
+of task objects, CSV data (`Content-Type: text/csv`), or an iCalendar file
+(`Content-Type: text/calendar`). Events within the calendar are converted to
+tasks and added to the currently authenticated user's list.
 
 ## Reminders
 


### PR DESCRIPTION
## Summary
- implement parsing of iCalendar files for import
- allow `POST /api/tasks/import` to accept `text/calendar`
- support ICS payload parsing via new `fromIcs` util
- document ICS import option in README
- test importing tasks from iCalendar

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cdc518a8883269f321bf3cb5d191c