### PR TITLE
Add custom recurrence rules

### DIFF
--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -410,6 +410,39 @@ test('last day recurring task uses last day of next month', async () => {
   expect(dates).toContain('2099-02-28');
 });
 
+test('custom recurring task schedules next month correctly', async () => {
+  const agent = request.agent(app);
+
+  let token = (await agent.get('/api/csrf-token')).body.csrfToken;
+  await agent
+    .post('/api/register')
+    .set('CSRF-Token', token)
+    .send({ username: 'custom', password: 'Passw0rd!' });
+
+  token = (await agent.get('/api/csrf-token')).body.csrfToken;
+  let res = await agent
+    .post('/api/tasks')
+    .set('CSRF-Token', token)
+    .send({
+      text: 'CR',
+      dueDate: '2099-01-20',
+      repeatInterval: 'custom',
+      recurrenceRule: { weekday: 2, ordinal: 3 }
+    });
+  const taskId = res.body.id;
+
+  token = (await agent.get('/api/csrf-token')).body.csrfToken;
+  await agent
+    .put(`/api/tasks/${taskId}`)
+    .set('CSRF-Token', token)
+    .send({ done: true });
+
+  res = await agent.get('/api/tasks?sort=dueDate');
+  const dates = res.body.map(t => t.dueDate).sort();
+  expect(dates).toContain('2099-01-20');
+  expect(dates).toContain('2099-02-17');
+});
+
 test('bulk update and delete', async () => {
   const agent = request.agent(app);
 


### PR DESCRIPTION
## Summary
- extend DB schema for recurrence rules
- implement parsing/formatting logic for recurrence rules
- support custom recurrence rules in API
- schedule next task using custom rules
- test custom recurrence scheduling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f3c44396c8326b1a948d463a749c4