### PR TITLE
Add notification templates and SMS alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ tab is not focused.
 ## Notification Preferences
 
 Each user can control whether they receive email reminders or notification
-emails for comments and task assignments. Retrieve your current settings with:
+emails for comments and task assignments. You can also enable SMS alerts and
+provide a custom template used for all notifications. Retrieve your current settings with:
 
 ```
 GET /api/preferences
@@ -194,7 +195,9 @@ Update them by sending:
 
 ```
 PUT /api/preferences
-{ "emailReminders": false, "emailNotifications": true }
+{ "emailReminders": false, "emailNotifications": true,
+  "notifySms": true, "phoneNumber": "+15551234567",
+  "notificationTemplate": "Task '{{text}}' - {{event}}" }
 ```
 
 ## Groups

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -54,6 +54,8 @@ Retrieve the current user's notification settings.
 
 ### `PUT /api/preferences`
 Update email reminder and notification preferences.
+You can also enable SMS notifications and provide a custom template using
+placeholders like `{{text}}`, `{{due}}`, `{{event}}` and `{{comment}}`.
 
 For additional routes such as groups, attachments and administrative
 endpoints refer to the [OpenAPI specification](openapi.yaml).

--- a/sms.js
+++ b/sms.js
@@ -1,0 +1,13 @@
+const sentSms = [];
+
+function sendSms(to, body) {
+  // For this demo we simply record the sms message.
+  sentSms.push({ to, body });
+  return Promise.resolve();
+}
+
+function clearSms() {
+  sentSms.length = 0;
+}
+
+module.exports = { sendSms, sentSms, clearSms };


### PR DESCRIPTION
## Summary
- support customizable notification templates
- allow SMS notifications via new sms.js
- include SMS and templates in preferences API
- document new options
- test SMS notifications and preferences

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686f57b5445883268190037e3da5458d