### PR TITLE
Add example env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Copy this file to .env and adjust the values as needed.
+# Required secret used to sign session cookies
+SESSION_SECRET=your_secret_here
+
+# Optional settings
+PORT=3000
+DB_FILE=tasks.db
+BCRYPT_ROUNDS=12
+DUE_SOON_CHECK_INTERVAL=60000
+ATTACHMENT_DIR=
+MAX_ATTACHMENT_SIZE=10485760
+TWO_FA_SECRET_TTL=600000
+WEBHOOK_URLS=
+
+# OAuth credentials
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# Calendar synchronization
+GOOGLE_SYNC_TOKEN=
+GOOGLE_CALENDAR_ID=
+OUTLOOK_SYNC_TOKEN=
+OUTLOOK_CALENDAR_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 tasks.db
 
+
+.env

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ export SESSION_SECRET=your_secret_here
 npm start
 ```
 
+An `.env.example` file lists all environment variables used by the application.
+Copy it to `.env`, edit the values and `source .env` (or otherwise export the
+variables) before starting the server.
+
 The server will run on port 3000 by default if no `PORT` variable is set.
 You can configure the bcrypt work factor with the `BCRYPT_ROUNDS` environment
 variable (default `12`). Higher values provide stronger hashing but increase CPU


### PR DESCRIPTION
## Summary
- provide `.env.example` with supported variables
- ignore `.env` in git
- document using `.env.example` in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870f7354f90832687194aadcaa72836