### PR TITLE
Add offline queue indicator

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -14,6 +14,7 @@
     </nav>
   </header>
   <div class="container">
+  <div id="offline-indicator" style="display:none;" aria-live="polite">Pending offline actions: <span id="offline-count">0</span></div>
   <div id="admin-content" style="display:none;">
     <h2>System Statistics</h2>
     <pre id="stats"></pre>

--- a/public/board.html
+++ b/public/board.html
@@ -17,6 +17,7 @@
   </header>
   <div class="container">
   <ul id="notifications" style="display:none;"></ul>
+  <div id="offline-indicator" style="display:none;" aria-live="polite">Pending offline actions: <span id="offline-count">0</span></div>
     <div id="auth">
       <form id="login-form">
         <label for="username-input">Username</label>

--- a/public/calendar.html
+++ b/public/calendar.html
@@ -15,6 +15,7 @@
   </header>
   <div class="container">
   <ul id="notifications" style="display:none;"></ul>
+  <div id="offline-indicator" style="display:none;" aria-live="polite">Pending offline actions: <span id="offline-count">0</span></div>
   <div id="auth">
     <form id="login-form">
       <label for="username-input">Username</label>

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,7 @@
   </header>
   <div class="container">
   <ul id="notifications" style="display:none;"></ul>
+  <div id="offline-indicator" style="display:none;" aria-live="polite">Pending offline actions: <span id="offline-count">0</span></div>
     <div id="auth">
       <form id="login-form">
         <label for="username-input">Username</label>

--- a/public/style.css
+++ b/public/style.css
@@ -90,6 +90,13 @@ label {
   color: blue;
 }
 
+#offline-indicator {
+  margin-bottom: 10px;
+  background: #ffeb3b;
+  padding: 4px;
+  border: 1px solid #e0c200;
+}
+
 /* Responsive layout for small screens */
 @media (max-width: 600px) {
   body {

--- a/public/sw-register.js
+++ b/public/sw-register.js
@@ -1,14 +1,34 @@
+function updateIndicator(len) {
+  const indicator = document.getElementById('offline-indicator');
+  const countSpan = document.getElementById('offline-count');
+  if (!indicator || !countSpan) return;
+  if (len > 0) {
+    indicator.style.display = 'block';
+    countSpan.textContent = len;
+  } else {
+    indicator.style.display = 'none';
+    countSpan.textContent = '0';
+  }
+}
+
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('service-worker.js').then(() => {
       if (navigator.serviceWorker.controller) {
         navigator.serviceWorker.controller.postMessage({ type: 'flush' });
+        navigator.serviceWorker.controller.postMessage({ type: 'getQueueLength' });
       }
     });
+  });
+  navigator.serviceWorker.addEventListener('message', e => {
+    if (e.data && e.data.type === 'queueLength') {
+      updateIndicator(e.data.length);
+    }
   });
   window.addEventListener('online', () => {
     if (navigator.serviceWorker.controller) {
       navigator.serviceWorker.controller.postMessage({ type: 'flush' });
+      navigator.serviceWorker.controller.postMessage({ type: 'getQueueLength' });
     }
   });
 }


### PR DESCRIPTION
## Summary
- broadcast queued request count from service worker
- show offline pending count on all pages
- style offline indicator
- request initial queue length from `sw-register.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710545237483268d1076a14b639584