### PR TITLE
Improve OAuth module handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ If Google or GitHub OAuth credentials are configured via environment variables
 (`GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` and `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET`),
 you can also log in using those providers from the login screen. The server only
 initializes the required Passport strategies when these variables are present.
-If the optional `passport`, `passport-google-oauth20` or `passport-github2`
-modules are missing, a warning is logged at startup and the OAuth routes will be
-unavailable.
+When OAuth credentials are set all required Passport modules must be installed.
+If any are missing the server will exit at startup rather than silently disabling
+OAuth routes. Remove the credentials or install the missing dependencies to
+proceed.
 
 Passwords must be at least 8 characters long and include upper and lower case
 letters and a number.

--- a/server.js
+++ b/server.js
@@ -34,8 +34,11 @@ if (enableGoogle || enableGithub) {
       GitHubStrategy = require('passport-github2').Strategy;
     }
   } catch (err) {
-    console.warn('Passport modules not installed; OAuth disabled');
-    passport = null;
+    console.error(
+      'Required Passport modules are missing. Install them or remove OAuth environment variables.'
+    );
+    console.error(err);
+    process.exit(1);
   }
 } else {
   console.warn('OAuth environment variables not set; skipping Passport initialization');


### PR DESCRIPTION
## Summary
- fail fast if Passport dependencies can't be loaded when OAuth env vars are set
- document the new startup behavior in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874ea9fbc688326bbaf7f8f9dfcc873