### PR TITLE
Improve password policy enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ OAuth routes. Remove the credentials or install the missing dependencies to
 proceed.
 
 Passwords must be at least 8 characters long and include upper and lower case
-letters and a number.
+letters, a number and a special character.
 
 ## Two-Factor Authentication
 

--- a/public/board.js
+++ b/public/board.js
@@ -1,6 +1,17 @@
 let currentUser = null;
 let csrfToken = '';
 
+function isStrongPassword(pw) {
+  return (
+    typeof pw === 'string' &&
+    pw.length >= 8 &&
+    /[a-z]/.test(pw) &&
+    /[A-Z]/.test(pw) &&
+    /[0-9]/.test(pw) &&
+    /[^A-Za-z0-9]/.test(pw)
+  );
+}
+
 document.getElementById('board').addEventListener('keydown', e => {
   if (e.target.tagName === 'LI') {
     if (e.key === 'ArrowUp' && e.target.previousElementSibling) {
@@ -159,6 +170,11 @@ document.getElementById('register-button').onclick = async () => {
   errorEl.textContent = '';
   if (!username || !password) {
     errorEl.textContent = 'Username and password are required';
+    return;
+  }
+  if (!isStrongPassword(password)) {
+    errorEl.textContent =
+      'Password must be at least 8 characters and include upper and lower case letters, a number and a special character';
     return;
   }
   if (username && password) {

--- a/public/calendar.js
+++ b/public/calendar.js
@@ -3,6 +3,17 @@ let csrfToken = '';
 let currentYear;
 let currentMonth;
 
+function isStrongPassword(pw) {
+  return (
+    typeof pw === 'string' &&
+    pw.length >= 8 &&
+    /[a-z]/.test(pw) &&
+    /[A-Z]/.test(pw) &&
+    /[0-9]/.test(pw) &&
+    /[^A-Za-z0-9]/.test(pw)
+  );
+}
+
 async function updateCsrfToken() {
   const res = await fetch('/api/csrf-token');
   const data = await res.json();
@@ -153,6 +164,11 @@ document.getElementById('register-button').onclick = async () => {
   errorEl.textContent = '';
   if (!username || !password) {
     errorEl.textContent = 'Username and password are required';
+    return;
+  }
+  if (!isStrongPassword(password)) {
+    errorEl.textContent =
+      'Password must be at least 8 characters and include upper and lower case letters, a number and a special character';
     return;
   }
   if (username && password) {

--- a/public/script.js
+++ b/public/script.js
@@ -35,6 +35,17 @@ let csrfToken = '';
 let eventSource = null;
 const selectedTasks = new Set();
 
+function isStrongPassword(pw) {
+  return (
+    typeof pw === 'string' &&
+    pw.length >= 8 &&
+    /[a-z]/.test(pw) &&
+    /[A-Z]/.test(pw) &&
+    /[0-9]/.test(pw) &&
+    /[^A-Za-z0-9]/.test(pw)
+  );
+}
+
 function tagColor(tag) {
   let hash = 0;
   for (let i = 0; i < tag.length; i++) {
@@ -480,6 +491,11 @@ document.getElementById('register-button').onclick = async () => {
   errorEl.textContent = '';
   if (!username || !password) {
     errorEl.textContent = 'Username and password are required';
+    return;
+  }
+  if (!isStrongPassword(password)) {
+    errorEl.textContent =
+      'Password must be at least 8 characters and include upper and lower case letters, a number and a special character';
     return;
   }
   if (username && password) {

--- a/server.js
+++ b/server.js
@@ -297,7 +297,8 @@ function isStrongPassword(pw) {
     pw.length >= 8 &&
     /[a-z]/.test(pw) &&
     /[A-Z]/.test(pw) &&
-    /[0-9]/.test(pw)
+    /[0-9]/.test(pw) &&
+    /[^A-Za-z0-9]/.test(pw)
   );
 }
 
@@ -524,7 +525,8 @@ app.post('/api/register', async (req, res) => {
   }
   if (!isStrongPassword(password)) {
     return res.status(400).json({
-      error: 'Password must be at least 8 characters and include upper and lower case letters and a number'
+      error:
+        'Password must be at least 8 characters and include upper and lower case letters, a number and a special character'
     });
   }
   try {
@@ -674,7 +676,7 @@ app.post('/api/reset-password', async (req, res) => {
   if (!isStrongPassword(password)) {
     return res.status(400).json({
       error:
-        'Password must be at least 8 characters and include upper and lower case letters and a number'
+        'Password must be at least 8 characters and include upper and lower case letters, a number and a special character'
     });
   }
   try {


### PR DESCRIPTION
## Summary
- enforce a stricter password policy on the server requiring a special character
- validate passwords client-side for registration
- document updated password requirements

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874f214bdb483269243c5d35ff980cb