### PR TITLE
Persist API rate limit counters in SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This will install `sqlite3` which is used for persistence. The database file
 Indexes on the `dueDate`, `userId` and `assignedTo` columns are created to keep
 common task queries fast.
 Session data is also stored in this database so it survives server restarts.
+Rate limit counters are persisted as well so limits continue to apply even after a restart.
 Session cookies are configured with `httpOnly`, `sameSite=lax` and
 `secure` (enabled when `NODE_ENV` is set to `production`) to help protect
 your session from client-side access and CSRF attacks. Additional HTTP


### PR DESCRIPTION
## Summary
- persist rate limiter state in SQLite
- expose new `incrementRateLimit` helper
- use persistent limiter for API and login routes
- mention rate limit persistence in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687582197ba4832685ad8f5206d99da8