### PR TITLE
Implement global error handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -1883,7 +1883,10 @@ app.use((err, req, res, next) => {
   if (err.code === 'EBADCSRFTOKEN') {
     return res.status(403).json({ error: 'Invalid CSRF token' });
   }
-  next(err);
+  if (res.headersSent) {
+    return next(err);
+  }
+  handleError(res, err, 'Internal server error');
 });
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- add final middleware to hide stack traces from error responses

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875853b5528832696312b6d1e10a936