### PR TITLE
Add ESLint and Prettier setup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": 12
+  },
+  "rules": {}
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ your session from client-side access and CSRF attacks. Additional HTTP
 security headers like HSTS and XSS protection are set using the
 `helmet` middleware.
 A Content Security Policy further restricts resource loading to this server and cdn.jsdelivr.net.
+## Linting and Formatting
+
+Run ESLint to check for coding issues and Prettier to automatically format files:
+
+```bash
+npm run lint
+npm run format
+```
+
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint .",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -22,6 +24,8 @@
   },
   "devDependencies": {
     "jest": "^29.6.1",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.5"
   }
 }


### PR DESCRIPTION
## Summary
- configure ESLint and Prettier
- document lint and format commands

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68759ddeac0c8326a7890fd2f4c6cd80