### PR TITLE
Improve provider setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,20 @@ TWILIO_AUTH_TOKEN=your_auth_token
 TWILIO_FROM_NUMBER=+15551234567
 ```
 
+Install the provider modules:
+
+```bash
+npm install @sendgrid/mail twilio
+```
+
+Create `.env` from the included template if needed and supply your credentials.
+You can also run the helper script to automate this step:
+
+```bash
+scripts/setup-providers.sh
+```
+
+
 When these variables are present and `@sendgrid/mail` or `twilio` are available,
 notifications will be sent through those services instead of being stored in
 memory for tests.

--- a/scripts/setup-providers.sh
+++ b/scripts/setup-providers.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+ENV_FILE=".env"
+if [ ! -f "$ENV_FILE" ]; then
+  cp .env.example "$ENV_FILE"
+  echo "Created $ENV_FILE from example template."
+fi
+update_var() {
+  key="$1"
+  prompt="$2"
+  current="$(grep -E "^$key=" "$ENV_FILE" | cut -d= -f2-)"
+  printf "%s [%s]: " "$prompt" "$current"
+  read value
+  if [ -z "$value" ]; then
+    value="$current"
+  fi
+  if grep -q "^$key=" "$ENV_FILE"; then
+    sed -i "s#^$key=.*#$key=$value#" "$ENV_FILE"
+  else
+    echo "$key=$value" >> "$ENV_FILE"
+  fi
+}
+update_var "SENDGRID_API_KEY" "SendGrid API Key"
+update_var "SENDGRID_FROM_EMAIL" "SendGrid From Email"
+update_var "TWILIO_ACCOUNT_SID" "Twilio Account SID"
+update_var "TWILIO_AUTH_TOKEN" "Twilio Auth Token"
+update_var "TWILIO_FROM_NUMBER" "Twilio From Number"
+echo "Updated $ENV_FILE with provider credentials."


### PR DESCRIPTION
## Summary
- add helper script `scripts/setup-providers.sh` to configure SendGrid and Twilio
- expand README with instructions for installing email/SMS provider packages and using the script

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875a26869448326b9674904907730ea