### PR TITLE
Improve environment config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ your session from client-side access and CSRF attacks. Additional HTTP
 security headers like HSTS and XSS protection are set using the
 `helmet` middleware.
 A Content Security Policy further restricts resource loading to this server and cdn.jsdelivr.net.
+
 ## Linting and Formatting
 
 Run ESLint to check for coding issues and Prettier to automatically format files:
@@ -41,7 +42,6 @@ Run ESLint to check for coding issues and Prettier to automatically format files
 npm run lint
 npm run format
 ```
-
 
 ## Usage
 
@@ -54,7 +54,9 @@ npm start
 
 An `.env.example` file lists all environment variables used by the application.
 Copy it to `.env`, edit the values and `source .env` (or otherwise export the
-variables) before starting the server.
+variables) before starting the server. Configuration values are validated at
+startup and the server will exit with a clear error message if any are missing
+or malformed.
 
 The server will run on port 3000 by default if no `PORT` variable is set.
 You can configure the bcrypt work factor with the `BCRYPT_ROUNDS` environment
@@ -150,7 +152,7 @@ const { csrfToken } = await res.json();
 await fetch('/api/tasks', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json', 'CSRF-Token': csrfToken },
-  body: JSON.stringify({ text: 'Example task' })
+  body: JSON.stringify({ text: 'Example task' }),
 });
 ```
 
@@ -374,7 +376,6 @@ You can also run the helper script to automate this step:
 ```bash
 scripts/setup-providers.sh
 ```
-
 
 When these variables are present and `@sendgrid/mail` or `twilio` are available,
 notifications will be sent through those services instead of being stored in

--- a/config.js
+++ b/config.js
@@ -1,9 +1,58 @@
 const path = require('path');
-module.exports = {
-  BCRYPT_ROUNDS: parseInt(process.env.BCRYPT_ROUNDS, 10) || 12,
-  TWO_FA_SECRET_TTL: parseInt(process.env.TWO_FA_SECRET_TTL, 10) || 10 * 60 * 1000,
-  MAX_ATTACHMENT_SIZE: parseInt(process.env.MAX_ATTACHMENT_SIZE, 10) || 10 * 1024 * 1024,
-  ATTACHMENT_DIR: process.env.ATTACHMENT_DIR,
-  ATTACHMENT_MIN_SPACE: parseInt(process.env.ATTACHMENT_MIN_SPACE, 10) || 0,
-  ATTACHMENT_QUOTA: parseInt(process.env.ATTACHMENT_QUOTA, 10) || 0
+
+function requiredStr(name) {
+  const val = process.env[name];
+  if (!val) {
+    throw new Error(`${name} environment variable is required`);
+  }
+  return val;
+}
+
+function str(name, def = '') {
+  const val = process.env[name];
+  return val !== undefined ? String(val) : def;
+}
+
+function num(name, def) {
+  const val = process.env[name];
+  if (val === undefined) return def;
+  const n = parseInt(val, 10);
+  if (Number.isNaN(n)) {
+    throw new Error(`${name} must be a number`);
+  }
+  return n;
+}
+
+const config = {
+  SESSION_SECRET: requiredStr('SESSION_SECRET'),
+  PORT: num('PORT', 3000),
+  DB_FILE: str('DB_FILE', path.join(__dirname, 'tasks.db')),
+  BCRYPT_ROUNDS: num('BCRYPT_ROUNDS', 12),
+  DUE_SOON_CHECK_INTERVAL: num('DUE_SOON_CHECK_INTERVAL', 60000),
+  DUE_SOON_BATCH_SIZE: num('DUE_SOON_BATCH_SIZE', 50),
+  TWO_FA_SECRET_TTL: num('TWO_FA_SECRET_TTL', 10 * 60 * 1000),
+  TOTP_STEP: num('TOTP_STEP', 30),
+  MAX_ATTACHMENT_SIZE: num('MAX_ATTACHMENT_SIZE', 10 * 1024 * 1024),
+  ATTACHMENT_DIR: str('ATTACHMENT_DIR', ''),
+  ATTACHMENT_MIN_SPACE: num('ATTACHMENT_MIN_SPACE', 0),
+  ATTACHMENT_QUOTA: num('ATTACHMENT_QUOTA', 0),
+  GOOGLE_CLIENT_ID: str('GOOGLE_CLIENT_ID', ''),
+  GOOGLE_CLIENT_SECRET: str('GOOGLE_CLIENT_SECRET', ''),
+  GITHUB_CLIENT_ID: str('GITHUB_CLIENT_ID', ''),
+  GITHUB_CLIENT_SECRET: str('GITHUB_CLIENT_SECRET', ''),
+  WEBHOOK_URLS: str('WEBHOOK_URLS', ''),
+  GOOGLE_SYNC_TOKEN: str('GOOGLE_SYNC_TOKEN', ''),
+  GOOGLE_CALENDAR_ID: str('GOOGLE_CALENDAR_ID', ''),
+  OUTLOOK_SYNC_TOKEN: str('OUTLOOK_SYNC_TOKEN', ''),
+  OUTLOOK_CALENDAR_ID: str('OUTLOOK_CALENDAR_ID', ''),
+  SENDGRID_API_KEY: str('SENDGRID_API_KEY', ''),
+  SENDGRID_FROM_EMAIL: str('SENDGRID_FROM_EMAIL', ''),
+  TWILIO_ACCOUNT_SID: str('TWILIO_ACCOUNT_SID', ''),
+  TWILIO_AUTH_TOKEN: str('TWILIO_AUTH_TOKEN', ''),
+  TWILIO_FROM_NUMBER: str('TWILIO_FROM_NUMBER', ''),
+  FCM_SERVER_KEY: str('FCM_SERVER_KEY', ''),
+  SLACK_BOT_TOKEN: str('SLACK_BOT_TOKEN', ''),
+  TEAMS_BOT_TOKEN: str('TEAMS_BOT_TOKEN', ''),
 };
+
+module.exports = config;

--- a/totp.js
+++ b/totp.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 
 const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
-const TOTP_STEP = parseInt(process.env.TOTP_STEP, 10) || 30;
+const { TOTP_STEP } = require('./config');
 
 function base32Encode(buf) {
   let bits = 0;
@@ -47,7 +47,8 @@ function totpToken(secret, step = TOTP_STEP, counterOffset = 0) {
   const counter = Math.floor(Date.now() / 1000 / step) + counterOffset;
   const buf = Buffer.alloc(8);
   buf.writeBigUInt64BE(BigInt(counter));
-  const hmac = crypto.createHmac('sha1', Buffer.from(secret, 'hex'))
+  const hmac = crypto
+    .createHmac('sha1', Buffer.from(secret, 'hex'))
     .update(buf)
     .digest();
   const offset = hmac[hmac.length - 1] & 0xf;
@@ -72,5 +73,5 @@ module.exports = {
   generateToken,
   base32Encode,
   base32Decode,
-  TOTP_STEP
+  TOTP_STEP,
 };


### PR DESCRIPTION
## Summary
- add simple config validation helper
- centralize environment parsing in `config.js`
- reference validated config in server and totp modules
- document startup validation in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run format` *(fails: syntax error in public/script.js)*

------
https://chatgpt.com/codex/tasks/task_e_68797d27c86c8326a049fc31a54c07a5