### PR TITLE
Add Dockerfile for containerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+tests
+*.md
+
+# ignore database and env files
+*.db
+.env
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-slim
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY . .
+ENV NODE_ENV=production
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -380,3 +380,21 @@ scripts/setup-providers.sh
 When these variables are present and `@sendgrid/mail` or `twilio` are available,
 notifications will be sent through those services instead of being stored in
 memory for tests.
+
+## Docker
+
+You can run the application in a container for a reproducible environment.
+Build the image with:
+
+```bash
+docker build -t web-task-tracker .
+```
+
+Start the server by passing in the required environment variables:
+
+```bash
+docker run -p 3000:3000 -e SESSION_SECRET=your_secret web-task-tracker
+```
+
+The container installs dependencies using `npm ci` and launches the server
+with `npm start` so you don't need Node.js installed locally.


### PR DESCRIPTION
## Summary
- add Dockerfile to run the app in a consistent Node 18 environment
- ignore unnecessary files when building Docker images
- document container usage in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879816f8ce883268bbb91f670685974