### PR TITLE
Add responsive mobile layout

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -140,6 +140,29 @@ label {
     margin: 4px 0;
     font-size: 16px;
   }
+
+  .container {
+    max-width: none;
+    padding: 10px;
+  }
+
+  nav {
+    display: flex;
+    flex-direction: column;
+  }
+
+  nav a {
+    margin: 5px 0;
+  }
+
+  #board {
+    flex-direction: column;
+  }
+
+  .board-column {
+    width: 100%;
+    margin-bottom: 10px;
+  }
 }
 
 #calendar {


### PR DESCRIPTION
## Summary
- make navigation and board view stack vertically on small screens
- allow container to span full width on phones

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dd2678c6c832695355bb5131bf35b