### PR TITLE
Add cloning and task template features

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -51,6 +51,21 @@ Import open issues from a GitHub repository as tasks. Provide an `owner` and
 `repo` in the request body. The server uses the `GITHUB_API_TOKEN` environment
 variable for authentication with GitHub.
 
+### `POST /api/tasks/{id}/clone`
+Create a new task by cloning an existing one along with its subtasks.
+
+### `GET /api/task-templates`
+List all saved task templates.
+
+### `POST /api/task-templates`
+Create a template from an existing task by providing a `name` and `taskId`.
+
+### `POST /api/task-templates/{id}/use`
+Create a new task based on the specified template.
+
+### `DELETE /api/task-templates/{id}`
+Remove a task template.
+
 ## Reminders
 
 ### `GET /api/reminders`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -216,6 +216,82 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Task'
+  /api/tasks/{id}/clone:
+    post:
+      summary: Clone an existing task
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '201':
+          description: Cloned task
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+  /api/task-templates:
+    get:
+      summary: List task templates
+      responses:
+        '200':
+          description: Array of templates
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TaskTemplate'
+    post:
+      summary: Create a task template
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                taskId:
+                  type: integer
+      responses:
+        '201':
+          description: Template created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskTemplate'
+  /api/task-templates/{id}/use:
+    post:
+      summary: Create a task from a template
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '201':
+          description: Created task
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+  /api/task-templates/{id}:
+    delete:
+      summary: Delete a task template
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Deleted
   /api/reports:
     get:
       summary: User reports
@@ -328,3 +404,12 @@ components:
           type: array
           items:
             type: integer
+    TaskTemplate:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        task:
+          $ref: '#/components/schemas/Task'


### PR DESCRIPTION
## Summary
- add new `task_templates` table and helper functions
- add endpoints for cloning tasks and managing templates
- update API docs and OpenAPI spec
- test cloning and template usage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dd8585f3c8326ad7eee5b9faf09c2